### PR TITLE
disabling existing repos with minimal settings

### DIFF
--- a/charts/nexus3/files/repo.groovy
+++ b/charts/nexus3/files/repo.groovy
@@ -19,13 +19,16 @@ if (existingRepository == null) {
   configuration.attributes = params.attributes
 } else {
   configuration = existingRepository.getConfiguration()
-
-  if (configuration.getRecipeName() != params.type) {
-    throw new Exception("Tried to change recipe for repo ${params.name} to ${params.type}")
+  if (params.containsKey("type")) {
+    if (configuration.getRecipeName() != params.type) {
+      throw new Exception("Tried to change recipe for repo ${params.name} to ${params.type}")
+    }
   }
 
   configuration.setOnline(params.online)
-  configuration.setAttributes(params.attributes)
+  if (params.containsKey("attributes")) {
+    configuration.setAttributes(params.attributes)
+  }
 }
 
 if (existingRepository == null) {

--- a/charts/nexus3/values.yaml
+++ b/charts/nexus3/values.yaml
@@ -188,7 +188,8 @@ config:
     #       strictContentTypeValidation: false
     #       writePolicy: ALLOW
     #     cleanup:
-    #       policyName: ExampleCleanup
+    #       policyName:
+    #         - ExampleCleanup
   tasks: []
     # - name: "Cleanup service"
     #   typeId: repository.cleanup


### PR DESCRIPTION
this commit allows disabling existing (pre-defined) repositories by only
setting the repo name and online status.

e.g.:

```
config:
  enable: true
  repos:
      # disable default repositories
          - name: "maven-central"
            online: false
```