### PR TITLE
[nexus3] Use postStart container lifecycle hook to run configure.sh

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
+## v3.3.6 - 2020-12-02
+
+### Changed
+
+- Re-ordered configure.sh so that roles are configured after repos
+- Removed background execution from configure.sh
+- Replaced container command and args with a lifecycle postStart hook
+
 ## v3.3.5 - 2020-12-01
 
 ### Changed

--- a/charts/nexus3/Chart.yaml
+++ b/charts/nexus3/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nexus3
-version: 3.3.5
+version: 3.3.6
 appVersion: 3.28.1
 description: Helm chart for Sonatype Nexus 3 OSS.
 keywords:

--- a/charts/nexus3/templates/deployment.yaml
+++ b/charts/nexus3/templates/deployment.yaml
@@ -74,15 +74,15 @@ spec:
             {{- with .Values.env }}
             {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
-          command:
-            - "sh"
-            - "-c"
-          args:
-            - echo "Starting Nexus...";
-              {{- if .Values.config.enabled }}
-              bash /opt/sonatype/nexus/conf/configure.sh;
-              {{- end }}
-              /opt/sonatype/start-nexus-repository-manager.sh;
+          {{- if .Values.config.enabled }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "${SONATYPE_DIR}/nexus/conf/configure.sh"
+          {{- end }}
           ports:
             - name: http
               containerPort: 8081


### PR DESCRIPTION
The following changes are included in this PR.

* Replaces the container command and args with a postStart lifecycle
* Removes the backgrounding of the outer loop in configure.sh 
* Fixes the order of configure.sh where the roles were still created prior to the repos.
* Updates comments in the anonymous user setup of configure.sh that mentioned metrics.
* Adds a default value for root_password in configure.sh in order to pass lint tests.

Closes #124 