### PR TITLE
[nexus3] move anonymous user for metrics configuration to end of configure.sh

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
+## v3.4.1 - 2020-12-14
+
+### Changed
+
+- Re-ordered configure.sh so that metrics are configured after roles
+
 ## v3.4.0 - 2020-12-07
 
 ### Changed

--- a/charts/nexus3/Chart.yaml
+++ b/charts/nexus3/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nexus3
-version: 3.4.0
+version: 3.4.1
 appVersion: 3.29.0
 description: Helm chart for Sonatype Nexus 3 OSS.
 keywords:

--- a/charts/nexus3/files/configure.sh
+++ b/charts/nexus3/files/configure.sh
@@ -149,21 +149,6 @@ do
     fi
   done
 
-  json_file="${base_dir}/conf/anonymous-user.json"
-  if [ -f "${json_file}" ]
-  then
-    echo "Configuring anonymous user for metrics..."
-
-    status_code="$(curl -s -o /dev/null -w "%{http_code}" -X PUT -H 'Content-Type: application/json' -u "${root_user}:${root_password}" -d "@${json_file}" "${nexus_host}/service/rest/beta/security/users/anonymous")"
-    if [ "${status_code}" -ne 204 ]
-    then
-      echo "Could not configure anonymous user for metrics." >&2
-      exit 1
-    fi
-
-    echo "Anonymous user for metrics configured."
-  fi
-
   for script_file in "${base_dir}"/conf/*.groovy
   do
     echo "Updating script ${script_file}."
@@ -275,6 +260,21 @@ do
       echo "Task configured."
     fi
   done
+
+  json_file="${base_dir}/conf/anonymous-user.json"
+  if [ -f "${json_file}" ]
+  then
+    echo "Configuring anonymous user for metrics..."
+
+    status_code="$(curl -s -o /dev/null -w "%{http_code}" -X PUT -H 'Content-Type: application/json' -u "${root_user}:${root_password}" -d "@${json_file}" "${nexus_host}/service/rest/beta/security/users/anonymous")"
+    if [ "${status_code}" -ne 204 ]
+    then
+      echo "Could not configure anonymous user for metrics." >&2
+      exit 1
+    fi
+
+    echo "Anonymous user for metrics configured."
+  fi
 
   echo "Configuration run successfully!"
   exit 0


### PR DESCRIPTION

In configure.sh, the section for configuring the anonymous user for metrics relies on the nx-metrics role. This PR moves it to the end of configure.sh.