### PR TITLE
fix(blobstore): get the real blobstore name when s3 is used

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
+## v4.0.3 - 2021-02-05
+
+### Changed
+
+- Fixed regex when S3 blobstore is used
+
 ## v4.0.2 - 2021-01-15
 
 ### Added

--- a/charts/nexus3/Chart.yaml
+++ b/charts/nexus3/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nexus3
 description: Helm chart for Sonatype Nexus 3 OSS.
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 3.29.2
 home: https://www.sonatype.com/nexus-repository-oss
 icon: https://help.sonatype.com/docs/files/331022/34537964/3/1564671303641/NexusRepo_Icon.png
@@ -21,5 +21,4 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - Added dynamic probe configuration
-    - Fixed typo in LDAP configuration
+    - Fixed regex when S3 blobstore is used

--- a/charts/nexus3/files/configure.sh
+++ b/charts/nexus3/files/configure.sh
@@ -124,8 +124,13 @@ do
   do
     if [ -f "${json_file}" ]
     then
-      name="$(grep -Pio '(?<="name":)\s*\"[^"]+\"' "${json_file}" | xargs)"
       type="$(grep -Pio '(?<="type":)\s*\"[^"]+\"' "${json_file}" | xargs)"
+      if [ "${type}" = "s3" ]
+      then
+        name="$(grep -Pio '(?<="name":)(\s*\"[^"]+\")(?=,"type":\"s3\")' "${json_file}" | xargs)"
+      else
+        name="$(grep -Pio '(?<="name":)\s*\"[^"]+\"' "${json_file}" | xargs)"
+      fi
       echo "Updating blob store '${name}'..."
 
       status_code=$(curl -s -o /dev/null -w "%{http_code}" -X GET -H 'Content-Type: application/json' -u "${root_user}:${root_password}" "${nexus_host}/service/rest/v1/blobstores/${type}/${name}")


### PR DESCRIPTION
Hello !

This commit permits to fix the regex used when we set s3 as a blob storage.
 
As an example, with this config:
```
{"bucketConfiguration":{"bucket":{"expiration":0,"name":"bucket-name","region":"eu-west-1"}},"name":"blobstore-name","type":"s3"}
```
The curent regex captures `bucket-name blobstore-name`, the first `GET curl` takes a `400` and the script tries to create an existing blobstore and fails. The new regex permits to capture the real name of the s3 blobstore.

Have a nice day,

(and thanks for you great work !)