### PR TITLE
[sonarqube] Added support for ALB SSL redirection

### DIFF
--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -31,10 +31,15 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
             backend:
+              {{- if .backend }}
+              serviceName: {{ .backend.serviceName | default $fullName }}
+              servicePort: {{ .backend.servicePort | default "http" }}
+              {{ else }}
               serviceName: {{ $fullName }}
               servicePort: http
+              {{ end -}}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -67,6 +67,11 @@ ingress:
   hosts:
     - host: chart-example.local
       paths: []
+        # - path: /*
+        #   backend:
+        #     serviceName: ssl-redirect
+        #     servicePort: use-annotation
+        # - path: /*
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
This change is intended for being able to [configure SSL redirection on AWS ALB](https://pet2cattle.com/2021/03/aws-ingress-alb-https-redirect)

I have added an example as a comment on the values.yaml to describe how to use it. This PR is generic enough to be able to use it on other scenarios as well