### PR TITLE
Change liveness and readyness mechanism

### DIFF
--- a/charts/jira-software/values.yaml
+++ b/charts/jira-software/values.yaml
@@ -29,8 +29,7 @@ podSecurityContext: {}
 priorityClassName: ""
 
 livenessProbe:
-  httpGet:
-    path: /status
+  tcpSocket:
     port: http
   initialDelaySeconds: 60
   periodSeconds: 30
@@ -38,8 +37,7 @@ livenessProbe:
   timeoutSeconds: 1
 
 readinessProbe:
-  httpGet:
-    path: /status
+  tcpSocket:
     port: http
   initialDelaySeconds: 60
   periodSeconds: 30


### PR DESCRIPTION
Full Re-Index fails because of 503 error code sent by Jira error page during the re-indexation. 
This causes Kubernetes to restart the pod while re-index is in progress.
I suggest to check TCP port and not /status which "force" application restart while Re-indexing.