### PR TITLE
[sonarqube] Add extra containers support

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
+## v3.2.0 - 2021-08-19
+
+### Added
+- Extra sidecar containers via `extraContainers`
+
 ## v3.1.0 - 2021-08-11
 
 ### Added

--- a/charts/sonarqube/Chart.lock
+++ b/charts/sonarqube/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami/
-  version: 10.3.17
-digest: sha256:15be3f863957d8e1b4de32b028626b5bb94111f01aede7bbb8b591e0ce05b88a
-generated: "2021-04-12T08:24:55.5091897+01:00"

--- a/charts/sonarqube/Chart.lock
+++ b/charts/sonarqube/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami/
+  version: 10.3.18
+digest: sha256:097913208cabc004680254f7872413053bf90a4e5d596b209d7b80e4d228a55e
+generated: "2021-08-19T08:32:48.370285-05:00"

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: A Helm chart for deploying SonarQube.
 type: application
-version: 3.1.0
+version: 3.2.0
 appVersion: 8.9.1
 keywords:
   - sonarqube
@@ -29,10 +29,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Pod labels via podlabels.
-    - kind: added
-      description: Extra volumes via extraVolumes and mounts for the sonarqube container via extraVolumeMounts.
-    - kind: added
-      description: Extra init containers via extraInitContainers, which can be templated.
-      - kind: removed
-      description: Init container _chmod-volume-mounts_ container as `fsGroup` should solve this issue.
+      description: Extra sidecar containers via extraContainers

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the _SonarQube_ chart a
 | `extraVolumeMounts`                | Additional volume mounts for the _sonarqube_ container.                                                                         | `[]`                                |
 | `resources`                        | Resource requests and limits for the _sonarqube_ container.                                                                     | `{}`                                |
 | `extraInitContainers`              | Additional init containers for the pod, these can be templated.                                                                 | `[]`                                |
+| `extraContainers`              | Additional containers for the pod, these can be templated.                                                                 | `[]`                                |
 | `extraVolumes`                     | Additional volumes for the pod.                                                                                                 | `[]`                                |
 | `nodeSelector`                     | Node labels for pod assignment.                                                                                                 | `{}`                                |
 | `tolerations`                      | Tolerations for pod assignment.                                                                                                 | `[]`                                |

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the _SonarQube_ chart a
 | `extraVolumeMounts`                | Additional volume mounts for the _sonarqube_ container.                                                                         | `[]`                                |
 | `resources`                        | Resource requests and limits for the _sonarqube_ container.                                                                     | `{}`                                |
 | `extraInitContainers`              | Additional init containers for the pod, these can be templated.                                                                 | `[]`                                |
-| `extraContainers`              | Additional containers for the pod, these can be templated.                                                                 | `[]`                                |
+| `extraContainers`              | Additional containers for the pod                                                                | `[]`                                |
 | `extraVolumes`                     | Additional volumes for the pod.                                                                                                 | `[]`                                |
 | `nodeSelector`                     | Node labels for pod assignment.                                                                                                 | `{}`                                |
 | `tolerations`                      | Tolerations for pod assignment.                                                                                                 | `[]`                                |

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -102,6 +102,9 @@ spec:
       {{- end }}
       {{- end }}
       containers:
+        {{- if .Values.extraContainers }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
         - name: sonarqube
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -102,9 +102,6 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        {{- if .Values.extraContainers }}
-        {{- toYaml .Values.extraContainers | nindent 8 }}
-        {{- end }}
         - name: sonarqube
           {{- with .Values.securityContext }}
           securityContext:
@@ -200,6 +197,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.extraContainers }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
       volumes:
         - name: sonarqube
           {{- if .Values.persistence.enabled }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -91,6 +91,8 @@ resources: {}
 
 extraInitContainers: []
 
+extraContainers: []
+
 extraVolumes: []
 
 nodeSelector: {}


### PR DESCRIPTION
This PR adds the ability to add extra containers that run as sidecars to a Sonarqube deployment, use cases such as proxies, log processors, gateways, etc. can be supported with this.

My personal use case is adding a CloudSQL proxy sidecar to the deployment, this sidecar has the following structure:

```
- name: cloud-sql-proxy
   image: gcr.io/cloudsql-docker/gce-proxy:1.24.0
   command:
   - "/cloud_sql_proxy"
   - "-ip_address_types=PRIVATE"
   - "-instances={instance-name}=tcp:5432"
   securityContext:
      runAsNonRoot: true
   resources:
      requests:
          memory: "2Gi"
          cpu:    "1"
```

The property is an array that allows adding multiple sidecars if desired