### PR TITLE
Sonarqube - Add a Ingress 'path' variable in values file

### DIFF
--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -3,6 +3,7 @@
 {{- $ingressSupportsPathType := eq (include "sonarqube.ingress.supportsPathType" .) "true" -}}
 {{- $serviceName := include "sonarqube.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
+{{- $path := .Values.ingress.path -}}
 apiVersion: {{ include "sonarqube.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -22,7 +23,7 @@ spec:
     - host: {{ quote . }}
       http:
         paths:
-          - path: /
+          - path: {{ $path }}
             {{- if $ingressSupportsPathType }}
             pathType: Prefix
             {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -61,6 +61,7 @@ ingress:
   annotations: {}
   ingressClassName: ""
   hosts: []
+  path: /
   #   - sonarqube.local
   tls: []
   #    - hosts:


### PR DESCRIPTION
When using this chart we ran into an issue when using an AWS ALB with Sonarqube. By default, the ingress path '/' does not support the wildcard * in AWS (the case may be different in other cloud providers). This means that after the Ingress ALB has been created, we need to manually go into the AWS console and add the wildcard (*) after the path '/'. This allows Sonarqube to function normally. Without doing this, none of the Sonarqube pages will load. 

A quick fix for this would be to add a 'path' variable to the values file which defaults to '/'. This will allow the user to override the default path with a custom path if needed (in our case -  /*) to accommodate for ALBs which do not support wildcard by default.