### PR TITLE
[sonarqube] Fix psql env variables bug

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
+## [v4.4.2] - 2022-04-12
+
+### Changed
+
+- Fixed _PostgreSQL_ env variables.
+
 ## [v4.4.1] - 2022-04-06
 
 ### Changed

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: A Helm chart for deploying SonarQube.
 type: application
-version: 4.4.1
+version: 4.4.2
 appVersion: 9.4.0
 keywords:
   - sonarqube
@@ -29,4 +29,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Fixed bad formatting when using embedded PostgreSQL chart."
+      description: "Fixed PostgreSQL env variables."

--- a/charts/sonarqube/_release-notes.md
+++ b/charts/sonarqube/_release-notes.md
@@ -1,3 +1,3 @@
-### Changed
+## Changed
 
-- Fixed bad formatting when using embedded _PostgreSQL_ chart.
+- Fixed _PostgreSQL_ env variables.

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -129,7 +129,7 @@ Lookup postgresql chart service port.
 {{- define "sonarqube.postgresql.servicePort" -}}
 {{- $values := merge .Values.postgresql (dict "global" .Values.global) -}}
 {{- $context := dict "Values" $values "Release" .Release "Chart" (dict "Name" "postgresql") "Template" .Template -}}
-{{ include "postgresql.service.port" $context }}
+{{ include "postgresql.servicePort" $context }}
 {{- end -}}
 
 {{/*

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -124,7 +124,7 @@ spec:
               value: {{ .Values.envVars.javaAdditionalOptionsCE | trim | quote }}
             {{- if .Values.postgresql.enabled }}
             - name: SONAR_JDBC_URL
-              value: {{ printf "jdbc:postgresql://%s:%d/%s" (include "sonarqube.postgresql.serviceName" .) (include "sonarqube.postgresql.servicePort" .) (include "sonarqube.postgresql.database" .) | quote }}
+              value: {{ printf "jdbc:postgresql://%s:%s/%s" (include "sonarqube.postgresql.serviceName" .) (include "sonarqube.postgresql.servicePort" .) (include "sonarqube.postgresql.database" .) | quote }}
             - name: SONAR_JDBC_USERNAME
               value: {{ include "sonarqube.postgresql.username" . | quote }}
             - name: SONAR_JDBC_PASSWORD
@@ -134,7 +134,7 @@ spec:
                   key: {{ if eq (include "sonarqube.postgresql.username" .) "postgres" }}postgresql-password{{ else }}password{{ end }}
             {{- else if .Values.psql }}
             - name: SONAR_JDBC_URL
-              value: {{ printf "jdbc:postgresql://%s:%s/%s" .Values.psql.host (default "5432" .Values.psql.port) .Values.psql.database | quote }}
+              value: {{ printf "jdbc:postgresql://%s:%v/%s" .Values.psql.host (default "5432" .Values.psql.port) .Values.psql.database | quote }}
             - name: SONAR_JDBC_USERNAME
               value: {{ .Values.psql.username | quote }}
             - name: SONAR_JDBC_PASSWORD


### PR DESCRIPTION
This PR fixes a typo in the code generating PostgreSQL env variables and the use of an incorrect embedded _PostgreSQL_ chart template.

Closes #446.