### PR TITLE
Nexus: Set ingress paths as templated values

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
+## [v4.14.2] - 2022-09-21
+
+### Changed
+
+- Set ingress path as templated value
+
 ## [v4.14.1] - 2022-08-22
 
 ### Changed

--- a/charts/nexus3/Chart.yaml
+++ b/charts/nexus3/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nexus3
 description: Helm chart for Sonatype Nexus 3 OSS.
 type: application
-version: 4.14.1
+version: 4.14.2
 appVersion: 3.41.1
 home: https://www.sonatype.com/nexus-repository-oss
 icon: https://help.sonatype.com/docs/files/331022/34537964/3/1564671303641/NexusRepo_Icon.png

--- a/charts/nexus3/files/configure.sh
+++ b/charts/nexus3/files/configure.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-nexus_host="http://localhost:8081"
+nexus_host="http://localhost:8081/${NEXUS_CONTEXT}"
 root_user="admin"
 base_dir="/opt/sonatype/nexus"
 out_file="/tmp/out.json"

--- a/charts/nexus3/templates/deployment.yaml
+++ b/charts/nexus3/templates/deployment.yaml
@@ -108,6 +108,10 @@ spec:
               {{- else }}
               value: {{ printf "-Xms%s -Xmx%s %s -Djava.util.prefs.userRoot=/nexus-data/javaprefs %s" .Values.envVars.jvmMinHeapSize .Values.envVars.jvmMaxHeapSize .Values.envVars.jvmAdditionalMemoryOptions .Values.envVars.jvmAdditionalOptions | quote }}
               {{- end }}
+              {{- if not (eq .Values.ingress.path "/") }}
+            - name: NEXUS_CONTEXT
+              value: {{ .Values.ingress.path | replace "/" "" }}
+              {{- end -}}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/nexus3/templates/ingress.yaml
+++ b/charts/nexus3/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ $.Values.ingress.path | quote }}
             {{- if $ingressSupportsPathType }}
             pathType: Prefix
             {{- end }}

--- a/charts/nexus3/values.yaml
+++ b/charts/nexus3/values.yaml
@@ -81,6 +81,7 @@ ingress:
   enabled: false
   annotations: {}
   ingressClassName: ""
+  path: /  # Note if you change path, you must prefix livenessProbe.httpGet.path & readinessProbe.httpGet.path with this string
   hosts: []
   #   - nexus.local
   tls: []


### PR DESCRIPTION
Path part of URL is currently hard-coded to "/". In other words, can only configure the host part of URL.

Required creating a new env var ["NEXUS_CONTEXT"](https://hub.docker.com/r/sonatype/nexus3#notes). This [must omit](https://github.com/sonatype/docker-nexus/issues/60#issuecomment-541326131) the leading "/". This PR accepts ingress.path with leading "/", but strips it when adding NEXUS_CONTEXT.

Also required appending path to `nexus_host` var in configure.sh, otherwise pod gets stuck initialising when `config.enabled`.