### PR TITLE
Fixes for thanos receivers

### DIFF
--- a/charts/thanos/templates/receive-ingestor/service-headless.yaml
+++ b/charts/thanos/templates/receive-ingestor/service-headless.yaml
@@ -21,10 +21,10 @@ spec:
       protocol: TCP
       port: 10902
       targetPort: http
-    - name: http-remote-write
+    - name: http-rem-write
       protocol: TCP
       port: 19291
-      targetPort: http-remote-write
+      targetPort: http-rem-write
   selector:
     {{- include "thanos.receiveIngestor.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/thanos/templates/receive-ingestor/statefulset.yaml
+++ b/charts/thanos/templates/receive-ingestor/statefulset.yaml
@@ -90,7 +90,7 @@ spec:
             - name: http
               protocol: TCP
               containerPort: 10902
-            - name: http-remote-write
+            - name: http-rem-write
               protocol: TCP
               containerPort: 19291
           livenessProbe:

--- a/charts/thanos/templates/receive-router/configmap-hashrings.yaml
+++ b/charts/thanos/templates/receive-router/configmap-hashrings.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receive.enabled -}}
+{{- if and .Values.receive.router.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/thanos/templates/receive-router/deployment.yaml
+++ b/charts/thanos/templates/receive-router/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.receive.enabled -}}
+{{- if .Values.receive.router.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/thanos/templates/receive-router/deployment.yaml
+++ b/charts/thanos/templates/receive-router/deployment.yaml
@@ -53,6 +53,10 @@ spec:
           image: {{ include "thanos.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: HOST_IP_ADDRESS
               valueFrom:
                 fieldRef:
@@ -67,6 +71,7 @@ spec:
             - --grpc-address=0.0.0.0:10901
             - --http-address=0.0.0.0:10902
             - --remote-write.address=0.0.0.0:19291
+            - --label=receive_replica="$(NAME)"
             - --receive.hashrings-file=/etc/thanos/hashrings.json
             - --receive.replication-factor={{ .Values.receive.replicationFactor }}
           {{- with .Values.receive.router.extraArgs }}

--- a/charts/thanos/templates/receive-router/deployment.yaml
+++ b/charts/thanos/templates/receive-router/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - --grpc-address=0.0.0.0:10901
             - --http-address=0.0.0.0:10902
             - --remote-write.address=0.0.0.0:19291
-            - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
+            - --receive.hashrings-file=/etc/thanos/hashrings.json
             - --receive.replication-factor={{ .Values.receive.replicationFactor }}
           {{- with .Values.receive.router.extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/charts/thanos/templates/receive-router/deployment.yaml
+++ b/charts/thanos/templates/receive-router/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: http
               protocol: TCP
               containerPort: 10902
-            - name: http-remote-write
+            - name: http-rem-write
               protocol: TCP
               containerPort: 19291
           livenessProbe:

--- a/charts/thanos/templates/receive-router/hpa.yaml
+++ b/charts/thanos/templates/receive-router/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.receive.enabled .Values.receive.router.autoscaling.enabled) (or .Values.receive.router.autoscaling.targetCPUUtilizationPercentage .Values.receive.router.autoscaling.targetMemoryUtilizationPercentage) -}}
+{{- if and (and .Values.receive.router.enabled .Values.receive.router.autoscaling.enabled) (or .Values.receive.router.autoscaling.targetCPUUtilizationPercentage .Values.receive.router.autoscaling.targetMemoryUtilizationPercentage) -}}
 apiVersion: {{ include "thanos.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/thanos/templates/receive-router/ingress.yaml
+++ b/charts/thanos/templates/receive-router/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receive.enabled .Values.receive.router.ingress.enabled -}}
+{{- if and .Values.receive.router.enabled .Values.receive.router.ingress.enabled -}}
 {{- $apiIsStable := eq (include "thanos.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "thanos.ingress.supportsPathType" .) "true" -}}
 {{- $serviceName := include "thanos.receiveRouter.fullname" . -}}

--- a/charts/thanos/templates/receive-router/pdb.yaml
+++ b/charts/thanos/templates/receive-router/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receive.enabled .Values.receive.router.podDisruptionBudget.enabled -}}
+{{- if and .Values.receive.router.enabled .Values.receive.router.podDisruptionBudget.enabled -}}
 apiVersion: {{ include "thanos.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/thanos/templates/receive-router/service.yaml
+++ b/charts/thanos/templates/receive-router/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.receive.enabled -}}
+{{- if .Values.receive.router.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/thanos/templates/receive-router/service.yaml
+++ b/charts/thanos/templates/receive-router/service.yaml
@@ -20,10 +20,10 @@ spec:
       protocol: TCP
       port: 10902
       targetPort: http
-    - name: http-remote-write
+    - name: http-rem-write
       protocol: TCP
       port: 19291
-      targetPort: http-remote-write
+      targetPort: http-rem-write
   selector:
     {{- include "thanos.receiveRouter.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/thanos/templates/receive-router/serviceaccount.yaml
+++ b/charts/thanos/templates/receive-router/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receive.enabled .Values.receive.router.serviceAccount.create -}}
+{{- if and .Values.receive.router.enabled .Values.receive.router.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/thanos/templates/receive-router/servicemonitor.yaml
+++ b/charts/thanos/templates/receive-router/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receive.enabled .Values.serviceMonitor.enabled -}}
+{{- if and .Values.receive.router.enabled .Values.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -377,6 +377,7 @@ receive:
     topologySpreadConstraints: {}
 
   router:
+    enabled: true
     serviceAccount:
       create: true
       labels: {}


### PR DESCRIPTION
- shorten service names `http-remote-write` to fix
```
Deployment.apps "thanos-receive-router" is invalid: spec.template.spec.containers[0].ports[2].name: Invalid value: "http-remote-write": must be no more than 15 characters
```
- Add `receive_` label to receive_router in order to make it start
- sync path of `hashrings.json` on receiver_router
- Add ability to disable receiver router

