### PR TITLE
Allow specific characters for ldap password

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security - In case of vulnerabilities.
 -->
 
+## [UNRELEASED]
+
+### Fixed
+
+- Allow to use `"` and `/` in the LDAP password
+
 ## [v4.34.0] - 2023-09-08
 
 ### Changed

--- a/charts/nexus3/files/configure.sh
+++ b/charts/nexus3/files/configure.sh
@@ -144,7 +144,7 @@ do
 
     if [[ -f "${base_dir}/secret/ldap.password" ]]
     then
-      ldap_password=$(cat "${base_dir}/secret/ldap.password")
+      ldap_password=$(cat "${base_dir}/secret/ldap.password" | sed 's|"|\\"|g;s|/|\\/|g')
       sed -i "s/PASSWORD/${ldap_password}/g" "${json_file}"
     fi
 


### PR DESCRIPTION
* Allow to use `"` and `/` in the LDAP password. By default sed return an error.