### PR TITLE
add note to nexus values regarding blob store configurations

### DIFF
--- a/charts/nexus3/values.yaml
+++ b/charts/nexus3/values.yaml
@@ -230,7 +230,7 @@ config:
     groupIdAttribute:
     groupMemberAttribute:
     groupMemberFormat:
-  blobStores: []
+  blobStores: []  # Reference the Nexus Blob store REST API for supported types and expected request body structures of each
   #   - name: ExampleFileBlobStore
   #     type: file
   #     path: /nexus-data/blobs/foo


### PR DESCRIPTION
It might not be immediately intuitive to reference the Nexus REST API for s3 (or other) blob store configuration settings. Adding note to nudge people in the right direction.