### PR TITLE
[nexus3] Allow to use \ in the LDAP password

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Allow to use `\` in the LDAP password
+
 ## [v4.40.0] - 2024-02-07
 
 ### Changed

--- a/charts/nexus3/files/configure.sh
+++ b/charts/nexus3/files/configure.sh
@@ -144,7 +144,7 @@ do
 
     if [[ -f "${base_dir}/secret/ldap.password" ]]
     then
-      ldap_password=$(cat "${base_dir}/secret/ldap.password" | sed 's|"|\\"|g;s|/|\\/|g')
+      ldap_password=$(cat "${base_dir}/secret/ldap.password" | sed 's|"|\\"|g;s|/|\\/|g;s|\\|\\\\|g')
       sed -i "s/PASSWORD/${ldap_password}/g" "${json_file}"
     fi
 


### PR DESCRIPTION
Allow to use `\` in the LDAP password (already tested)