### PR TITLE
Adding request extra to support value like "nvidia.com/gpu: 1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,46 @@
-# overprovisioner
+# Kubernetes Helm Charts
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stevehipwell)](https://artifacthub.io/packages/search?ts_query_web=stevehipwell&sort=last_updated)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![](https://github.com/stevehipwell/helm-charts/workflows/Release/badge.svg?branch=main)](https://github.com/stevehipwell/helm-charts/actions/workflows/release.yaml)
 
-Helm chart for overprovisioning Kubernetes clusters.
+## Usage
 
-**Homepage:** <https://github.com/stevehipwell/helm-charts/>
+[Helm](https://helm.sh) must be installed to use these charts; please refer to the _Helm_ [documentation](https://helm.sh/docs/) to get started.
 
-## Maintainers
+### OCI Repositories
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| stevehipwell | <steve.hipwell@gmail.com> |  |
-
-## Source Code
-
-* <https://github.com/stevehipwell/helm-charts/>
-
-## Installing the Chart
-
-### OCI Repository
-
-To install the chart using the recommended OCI method you can use the following command.
-
-```shell
-helm upgrade --install overprovisioner oci://ghcr.io/stevehipwell/helm-charts/overprovisioner --version 0.3.0
-```
-
-#### Verification
-
-As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
-
-```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository stevehipwell/helm-charts --certificate-github-workflow-name Release ghcr.io/stevehipwell/helm-charts/overprovisioner:0.3.0
-```
+The recommended way to install these charts is via OCI and the `helm search hub stevehipwell` command should list the available charts.
 
 ### Non-OCI Repository
 
-Alternatively you can use the legacy non-OCI method via the following commands.
+If you don't want to use the OCI repositories you can add the `stevehipwell` repository as follows.
 
 ```shell
 helm repo add stevehipwell https://stevehipwell.github.io/helm-charts/
-helm upgrade --install overprovisioner stevehipwell/overprovisioner --version 0.3.0
+helm repo update
 ```
 
-## Values
+You can then run `helm search repo stevehipwell` to see the charts.
 
-| Key                                      | Type   | Default                                                 | Description                                                                                                                                                                                                                                           |
-|------------------------------------------|--------|---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| autoscaler.affinity                      | object | `{}`                                                    | Affinity settings for scheduling the _Autoscaler_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.                                                    |
-| autoscaler.image.pullPolicy              | string | `"IfNotPresent"`                                        | Image pull policy for the _Autoscaler_ component default container.                                                                                                                                                                                   |
-| autoscaler.image.repository              | string | `"registry.k8s.io/cpa/cluster-proportional-autoscaler"` | Image repository for the _Autoscaler_ component default container.                                                                                                                                                                                    |
-| autoscaler.image.tag                     | string | `"v1.8.9"`                                              | Image tag for the _Autoscaler_ component default container.                                                                                                                                                                                           |
-| autoscaler.logLevel                      | int    | `2`                                                     | Log level for the _Autoscaler_ component.                                                                                                                                                                                                             |
-| autoscaler.nodeSelector                  | object | `{}`                                                    | Node selector labels for scheduling the _Autoscaler_ component.                                                                                                                                                                                       |
-| autoscaler.podAnnotations                | object | `{}`                                                    | Annotations to add to the _Autoscaler_ pod.                                                                                                                                                                                                           |
-| autoscaler.podLabels                     | object | `{}`                                                    | Labels to add to the _Autoscaler_ pod.                                                                                                                                                                                                                |
-| autoscaler.podSecurityContext            | object | See _values.yaml_                                       | Security context for the _Autoscaler_ pod.                                                                                                                                                                                                            |
-| autoscaler.priorityClassName             | string | `nil`                                                   | Priority class name for the _Autoscaler_ pod.                                                                                                                                                                                                         |
-| autoscaler.resources                     | object | `{}`                                                    | Resources for the _Autoscaler_ component default container.                                                                                                                                                                                           |
-| autoscaler.securityContext               | object | See _values.yaml_                                       | Security context for the _Autoscaler_ component default container.                                                                                                                                                                                    |
-| autoscaler.serviceAccount.annotations    | object | `{}`                                                    | Annotations to add to the _Autoscaler_ service account.                                                                                                                                                                                               |
-| autoscaler.serviceAccount.create         | bool   | `true`                                                  | If `true`, create a new `ServiceAccount` for the _Autoscaler_ component.                                                                                                                                                                              |
-| autoscaler.serviceAccount.labels         | object | `{}`                                                    | Labels to add to the _Autoscaler_ service account.                                                                                                                                                                                                    |
-| autoscaler.serviceAccount.name           | string | `nil`                                                   | If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Autoscaler_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use. |
-| autoscaler.terminationGracePeriodSeconds | int    | `nil`                                                   | Termination grace period for the _Autoscaler_ pod; in seconds.                                                                                                                                                                                        |
-| autoscaler.tolerations                   | list   | `[]`                                                    | Node taints the _Autoscaler_ component will tolerate for scheduling.                                                                                                                                                                                  |
-| autoscaler.topologySpreadConstraints     | list   | `[]`                                                    | Topology spread constraints for scheduling for the _Autoscaler_ component. If an explicit label selector is not provided one will be created from the pod selector labels.                                                                            |
-| capacity.auto.coresPerReplica            | int    | `4`                                                     | Number of pause pod replicas to create per cluster core; if `capacity.mode` is `auto`.                                                                                                                                                                |
-| capacity.auto.maxReplicas                | int    | `1`                                                     | Maximum number of pause pod replicas to create; if `capacity.mode` is `auto`.                                                                                                                                                                         |
-| capacity.auto.minReplicas                | int    | `1`                                                     | Minimum number of pause pod replicas to create; if `capacity.mode` is `auto`.                                                                                                                                                                         |
-| capacity.auto.nodesPerReplica            | int    | `1`                                                     | Number of pause pod replicas to create per cluster node; if `capacity.mode` is `auto`.                                                                                                                                                                |
-| capacity.fixed.replicas                  | int    | `1`                                                     | Number of pause pod replicas to create; if `capacity.mode` is `fixed`.                                                                                                                                                                                |
-| capacity.mode                            | string | `"fixed"`                                               | Capacity mode to use; one of `fixed` or `auto`. If `auto` is used, a [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) deployment will be used to scale the pause pods                            |
-| capacity.resources.cpu                   | string | `"10m"`                                                 | CPU resource requests and limits for the pause pods.                                                                                                                                                                                                  |
-| capacity.resources.memory                | string | `"16Mi"`                                                | Memory resource requests and limits for the pause pods.                                                                                                                                                                                               |
-| capacity.resources.extra                 | object | `{}`                                                    | Extra resource to add.                                                                                                                                                                          |
-| commonLabels                             | object | `{}`                                                    | Labels to add to all chart resources.                                                                                                                                                                                                                 |
-| fullnameOverride                         | string | `nil`                                                   | Override the full name of the chart.                                                                                                                                                                                                                  |
-| imagePullSecrets                         | list   | `[]`                                                    | Image pull secrets.                                                                                                                                                                                                                                   |
-| nameOverride                             | string | `nil`                                                   | Override the name of the chart.                                                                                                                                                                                                                       |
-| pause.affinity                           | object | `{}`                                                    | Affinity settings for scheduling the _Pause_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.                                                         |
-| pause.image.pullPolicy                   | string | `"IfNotPresent"`                                        | Image pull policy for the _Pause_ component default container.                                                                                                                                                                                        |
-| pause.image.repository                   | string | `"registry.k8s.io/pause"`                               | Image repository for the _Pause_ component default container.                                                                                                                                                                                         |
-| pause.image.tag                          | float  | `3.9`                                                   | Image tag for the _Pause_ component default container.                                                                                                                                                                                                |
-| pause.nodeSelector                       | object | `{}`                                                    | Node selector labels for scheduling the _Pause_ component.                                                                                                                                                                                            |
-| pause.podAnnotations                     | object | `{}`                                                    | Annotations to add to the _Pause_ pod.                                                                                                                                                                                                                |
-| pause.podLabels                          | object | `{}`                                                    | Labels to add to the _Pause_ pod.                                                                                                                                                                                                                     |
-| pause.serviceAccount.annotations         | object | `{}`                                                    | Annotations to add to the _Pause_ service account.                                                                                                                                                                                                    |
-| pause.serviceAccount.create              | bool   | `true`                                                  | If `true`, create a new `ServiceAccount` for the _Pause_ component.                                                                                                                                                                                   |
-| pause.serviceAccount.labels              | object | `{}`                                                    | Labels to add to the _Pause_ service account.                                                                                                                                                                                                         |
-| pause.serviceAccount.name                | string | `nil`                                                   | If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Pause_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use.      |
-| pause.tolerations                        | list   | `[]`                                                    | Node taints the _Pause_ component will tolerate for scheduling.                                                                                                                                                                                       |
-| pause.topologySpreadConstraints          | list   | `[]`                                                    | Topology spread constraints for scheduling for the _Pause_ component. If an explicit label selector is not provided one will be created from the pod selector labels.                                                                                 |
-| priorityClass.annotations                | object | `{}`                                                    | Annotations to add to the priority class.                                                                                                                                                                                                             |
-| priorityClass.create                     | bool   | `true`                                                  | If `true`, create a new preemptible `PriorityClass`.                                                                                                                                                                                                  |
-| priorityClass.labels                     | object | `{}`                                                    | Labels to add to the priority class.                                                                                                                                                                                                                  |
-| priorityClass.name                       | string | `nil`                                                   | If this is set and `priorityClass.create` is `true` this will be used for the created priority class name, if set and `priorityClass.create` is `false` then this will define an existing priority class to use.                                      |
-| priorityClass.value                      | int    | `-1`                                                    | Value for the priority class.                                                                                                                                                                                                                         |
+## Charts
 
-----------------------------------------------
+- [confluence-server](./charts/confluence-server/README.md)
+- [fluent-bit-aggregator](./charts/fluent-bit-aggregator/README.md)
+- [fluent-bit-collector](./charts/fluent-bit-collector/README.md)
+- [fluentd-aggregator](./charts/fluentd-aggregator/README.md)
+- [istio-operator](./charts/istio-operator/README.md)
+- [jira-software](./charts/jira-software/README.md)
+- [k8s-resources](./charts/k8s-resources/README.md)
+- [nexus3](./charts/nexus3/README.md)
+- [node-config](./charts/node-config/README.md)
+- [overprovisioner](./charts/overprovisioner/README.md)
+- [plantuml](./charts/plantuml/README.md)
+- [sonarqube](./charts/sonarqube/README.md)
+- [thanos](./charts/thanos/README.md)
+- [tigera-operator](./charts/tigera-operator/README.md)
+- [vertical-pod-autoscaler](./charts/vertical-pod-autoscaler/README.md)
 
-Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs/).
+## License
+
+[MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,46 +1,103 @@
-# Kubernetes Helm Charts
+# overprovisioner
 
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stevehipwell)](https://artifacthub.io/packages/search?ts_query_web=stevehipwell&sort=last_updated)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![](https://github.com/stevehipwell/helm-charts/workflows/Release/badge.svg?branch=main)](https://github.com/stevehipwell/helm-charts/actions/workflows/release.yaml)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
-## Usage
+Helm chart for overprovisioning Kubernetes clusters.
 
-[Helm](https://helm.sh) must be installed to use these charts; please refer to the _Helm_ [documentation](https://helm.sh/docs/) to get started.
+**Homepage:** <https://github.com/stevehipwell/helm-charts/>
 
-### OCI Repositories
+## Maintainers
 
-The recommended way to install these charts is via OCI and the `helm search hub stevehipwell` command should list the available charts.
+| Name | Email | Url |
+| ---- | ------ | --- |
+| stevehipwell | <steve.hipwell@gmail.com> |  |
+
+## Source Code
+
+* <https://github.com/stevehipwell/helm-charts/>
+
+## Installing the Chart
+
+### OCI Repository
+
+To install the chart using the recommended OCI method you can use the following command.
+
+```shell
+helm upgrade --install overprovisioner oci://ghcr.io/stevehipwell/helm-charts/overprovisioner --version 0.3.0
+```
+
+#### Verification
+
+As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
+
+```shell
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository stevehipwell/helm-charts --certificate-github-workflow-name Release ghcr.io/stevehipwell/helm-charts/overprovisioner:0.3.0
+```
 
 ### Non-OCI Repository
 
-If you don't want to use the OCI repositories you can add the `stevehipwell` repository as follows.
+Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add stevehipwell https://stevehipwell.github.io/helm-charts/
-helm repo update
+helm upgrade --install overprovisioner stevehipwell/overprovisioner --version 0.3.0
 ```
 
-You can then run `helm search repo stevehipwell` to see the charts.
+## Values
 
-## Charts
+| Key                                      | Type   | Default                                                 | Description                                                                                                                                                                                                                                           |
+|------------------------------------------|--------|---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| autoscaler.affinity                      | object | `{}`                                                    | Affinity settings for scheduling the _Autoscaler_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.                                                    |
+| autoscaler.image.pullPolicy              | string | `"IfNotPresent"`                                        | Image pull policy for the _Autoscaler_ component default container.                                                                                                                                                                                   |
+| autoscaler.image.repository              | string | `"registry.k8s.io/cpa/cluster-proportional-autoscaler"` | Image repository for the _Autoscaler_ component default container.                                                                                                                                                                                    |
+| autoscaler.image.tag                     | string | `"v1.8.9"`                                              | Image tag for the _Autoscaler_ component default container.                                                                                                                                                                                           |
+| autoscaler.logLevel                      | int    | `2`                                                     | Log level for the _Autoscaler_ component.                                                                                                                                                                                                             |
+| autoscaler.nodeSelector                  | object | `{}`                                                    | Node selector labels for scheduling the _Autoscaler_ component.                                                                                                                                                                                       |
+| autoscaler.podAnnotations                | object | `{}`                                                    | Annotations to add to the _Autoscaler_ pod.                                                                                                                                                                                                           |
+| autoscaler.podLabels                     | object | `{}`                                                    | Labels to add to the _Autoscaler_ pod.                                                                                                                                                                                                                |
+| autoscaler.podSecurityContext            | object | See _values.yaml_                                       | Security context for the _Autoscaler_ pod.                                                                                                                                                                                                            |
+| autoscaler.priorityClassName             | string | `nil`                                                   | Priority class name for the _Autoscaler_ pod.                                                                                                                                                                                                         |
+| autoscaler.resources                     | object | `{}`                                                    | Resources for the _Autoscaler_ component default container.                                                                                                                                                                                           |
+| autoscaler.securityContext               | object | See _values.yaml_                                       | Security context for the _Autoscaler_ component default container.                                                                                                                                                                                    |
+| autoscaler.serviceAccount.annotations    | object | `{}`                                                    | Annotations to add to the _Autoscaler_ service account.                                                                                                                                                                                               |
+| autoscaler.serviceAccount.create         | bool   | `true`                                                  | If `true`, create a new `ServiceAccount` for the _Autoscaler_ component.                                                                                                                                                                              |
+| autoscaler.serviceAccount.labels         | object | `{}`                                                    | Labels to add to the _Autoscaler_ service account.                                                                                                                                                                                                    |
+| autoscaler.serviceAccount.name           | string | `nil`                                                   | If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Autoscaler_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use. |
+| autoscaler.terminationGracePeriodSeconds | int    | `nil`                                                   | Termination grace period for the _Autoscaler_ pod; in seconds.                                                                                                                                                                                        |
+| autoscaler.tolerations                   | list   | `[]`                                                    | Node taints the _Autoscaler_ component will tolerate for scheduling.                                                                                                                                                                                  |
+| autoscaler.topologySpreadConstraints     | list   | `[]`                                                    | Topology spread constraints for scheduling for the _Autoscaler_ component. If an explicit label selector is not provided one will be created from the pod selector labels.                                                                            |
+| capacity.auto.coresPerReplica            | int    | `4`                                                     | Number of pause pod replicas to create per cluster core; if `capacity.mode` is `auto`.                                                                                                                                                                |
+| capacity.auto.maxReplicas                | int    | `1`                                                     | Maximum number of pause pod replicas to create; if `capacity.mode` is `auto`.                                                                                                                                                                         |
+| capacity.auto.minReplicas                | int    | `1`                                                     | Minimum number of pause pod replicas to create; if `capacity.mode` is `auto`.                                                                                                                                                                         |
+| capacity.auto.nodesPerReplica            | int    | `1`                                                     | Number of pause pod replicas to create per cluster node; if `capacity.mode` is `auto`.                                                                                                                                                                |
+| capacity.fixed.replicas                  | int    | `1`                                                     | Number of pause pod replicas to create; if `capacity.mode` is `fixed`.                                                                                                                                                                                |
+| capacity.mode                            | string | `"fixed"`                                               | Capacity mode to use; one of `fixed` or `auto`. If `auto` is used, a [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) deployment will be used to scale the pause pods                            |
+| capacity.resources.cpu                   | string | `"10m"`                                                 | CPU resource requests and limits for the pause pods.                                                                                                                                                                                                  |
+| capacity.resources.memory                | string | `"16Mi"`                                                | Memory resource requests and limits for the pause pods.                                                                                                                                                                                               |
+| capacity.resources.extra                 | object | `{}`                                                    | Extra resource to add.                                                                                                                                                                          |
+| commonLabels                             | object | `{}`                                                    | Labels to add to all chart resources.                                                                                                                                                                                                                 |
+| fullnameOverride                         | string | `nil`                                                   | Override the full name of the chart.                                                                                                                                                                                                                  |
+| imagePullSecrets                         | list   | `[]`                                                    | Image pull secrets.                                                                                                                                                                                                                                   |
+| nameOverride                             | string | `nil`                                                   | Override the name of the chart.                                                                                                                                                                                                                       |
+| pause.affinity                           | object | `{}`                                                    | Affinity settings for scheduling the _Pause_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.                                                         |
+| pause.image.pullPolicy                   | string | `"IfNotPresent"`                                        | Image pull policy for the _Pause_ component default container.                                                                                                                                                                                        |
+| pause.image.repository                   | string | `"registry.k8s.io/pause"`                               | Image repository for the _Pause_ component default container.                                                                                                                                                                                         |
+| pause.image.tag                          | float  | `3.9`                                                   | Image tag for the _Pause_ component default container.                                                                                                                                                                                                |
+| pause.nodeSelector                       | object | `{}`                                                    | Node selector labels for scheduling the _Pause_ component.                                                                                                                                                                                            |
+| pause.podAnnotations                     | object | `{}`                                                    | Annotations to add to the _Pause_ pod.                                                                                                                                                                                                                |
+| pause.podLabels                          | object | `{}`                                                    | Labels to add to the _Pause_ pod.                                                                                                                                                                                                                     |
+| pause.serviceAccount.annotations         | object | `{}`                                                    | Annotations to add to the _Pause_ service account.                                                                                                                                                                                                    |
+| pause.serviceAccount.create              | bool   | `true`                                                  | If `true`, create a new `ServiceAccount` for the _Pause_ component.                                                                                                                                                                                   |
+| pause.serviceAccount.labels              | object | `{}`                                                    | Labels to add to the _Pause_ service account.                                                                                                                                                                                                         |
+| pause.serviceAccount.name                | string | `nil`                                                   | If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Pause_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use.      |
+| pause.tolerations                        | list   | `[]`                                                    | Node taints the _Pause_ component will tolerate for scheduling.                                                                                                                                                                                       |
+| pause.topologySpreadConstraints          | list   | `[]`                                                    | Topology spread constraints for scheduling for the _Pause_ component. If an explicit label selector is not provided one will be created from the pod selector labels.                                                                                 |
+| priorityClass.annotations                | object | `{}`                                                    | Annotations to add to the priority class.                                                                                                                                                                                                             |
+| priorityClass.create                     | bool   | `true`                                                  | If `true`, create a new preemptible `PriorityClass`.                                                                                                                                                                                                  |
+| priorityClass.labels                     | object | `{}`                                                    | Labels to add to the priority class.                                                                                                                                                                                                                  |
+| priorityClass.name                       | string | `nil`                                                   | If this is set and `priorityClass.create` is `true` this will be used for the created priority class name, if set and `priorityClass.create` is `false` then this will define an existing priority class to use.                                      |
+| priorityClass.value                      | int    | `-1`                                                    | Value for the priority class.                                                                                                                                                                                                                         |
 
-- [confluence-server](./charts/confluence-server/README.md)
-- [fluent-bit-aggregator](./charts/fluent-bit-aggregator/README.md)
-- [fluent-bit-collector](./charts/fluent-bit-collector/README.md)
-- [fluentd-aggregator](./charts/fluentd-aggregator/README.md)
-- [istio-operator](./charts/istio-operator/README.md)
-- [jira-software](./charts/jira-software/README.md)
-- [k8s-resources](./charts/k8s-resources/README.md)
-- [nexus3](./charts/nexus3/README.md)
-- [node-config](./charts/node-config/README.md)
-- [overprovisioner](./charts/overprovisioner/README.md)
-- [plantuml](./charts/plantuml/README.md)
-- [sonarqube](./charts/sonarqube/README.md)
-- [thanos](./charts/thanos/README.md)
-- [tigera-operator](./charts/tigera-operator/README.md)
-- [vertical-pod-autoscaler](./charts/vertical-pod-autoscaler/README.md)
+----------------------------------------------
 
-## License
-
-[MIT License](./LICENSE).
+Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs/).

--- a/charts/overprovisioner/CHANGELOG.md
+++ b/charts/overprovisioner/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ## [UNRELEASED]
 
+### Changed
+
+- Updating `spec.template.spec.containers.resources` to be object map to support multiple resource types.
+
+
 ## [v0.3.0] - 2024-01-17
 
 ### Changed

--- a/charts/overprovisioner/README.md
+++ b/charts/overprovisioner/README.md
@@ -72,7 +72,7 @@ helm upgrade --install overprovisioner stevehipwell/overprovisioner --version 0.
 | capacity.auto.nodesPerReplica | int | `1` | Number of pause pod replicas to create per cluster node; if `capacity.mode` is `auto`. |
 | capacity.fixed.replicas | int | `1` | Number of pause pod replicas to create; if `capacity.mode` is `fixed`. |
 | capacity.mode | string | `"fixed"` | Capacity mode to use; one of `fixed` or `auto`. If `auto` is used, a [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) deployment will be used to scale the pause pods |
-| capacity.resources | object | `{}` | map of resources |
+| capacity.resources | object | See _values.yaml_ | map of resources |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |
 | imagePullSecrets | list | `[]` | Image pull secrets. |

--- a/charts/overprovisioner/README.md
+++ b/charts/overprovisioner/README.md
@@ -72,7 +72,7 @@ helm upgrade --install overprovisioner stevehipwell/overprovisioner --version 0.
 | capacity.auto.nodesPerReplica | int | `1` | Number of pause pod replicas to create per cluster node; if `capacity.mode` is `auto`. |
 | capacity.fixed.replicas | int | `1` | Number of pause pod replicas to create; if `capacity.mode` is `fixed`. |
 | capacity.mode | string | `"fixed"` | Capacity mode to use; one of `fixed` or `auto`. If `auto` is used, a [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) deployment will be used to scale the pause pods |
-| capacity.resources | object | See _values.yaml_ | map of resources |
+| capacity.resources | object | See _values.yaml_ | Map of resources to provision. |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |
 | imagePullSecrets | list | `[]` | Image pull secrets. |

--- a/charts/overprovisioner/README.md
+++ b/charts/overprovisioner/README.md
@@ -72,8 +72,7 @@ helm upgrade --install overprovisioner stevehipwell/overprovisioner --version 0.
 | capacity.auto.nodesPerReplica | int | `1` | Number of pause pod replicas to create per cluster node; if `capacity.mode` is `auto`. |
 | capacity.fixed.replicas | int | `1` | Number of pause pod replicas to create; if `capacity.mode` is `fixed`. |
 | capacity.mode | string | `"fixed"` | Capacity mode to use; one of `fixed` or `auto`. If `auto` is used, a [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) deployment will be used to scale the pause pods |
-| capacity.resources.cpu | string | `"10m"` | CPU resource requests and limits for the pause pods. |
-| capacity.resources.memory | string | `"16Mi"` | Memory resource requests and limits for the pause pods. |
+| capacity.resources | object | `{}` | map of resources |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |
 | imagePullSecrets | list | `[]` | Image pull secrets. |

--- a/charts/overprovisioner/templates/pause/deployment.yaml
+++ b/charts/overprovisioner/templates/pause/deployment.yaml
@@ -52,15 +52,11 @@ spec:
           imagePullPolicy: {{ .Values.pause.image.pullPolicy }}
           resources:
             requests:
-              cpu: {{ .Values.capacity.resources.cpu }}
-              memory: {{ .Values.capacity.resources.memory }}
-              {{- with .Values.capacity.resources.extra }}
+              {{- with .Values.capacity.resources }}
               {{- toYaml . | nindent 14 }}
               {{- end }}
             limits:
-              cpu: {{ .Values.capacity.resources.cpu }}
-              memory: {{ .Values.capacity.resources.memory }}
-              {{- with .Values.capacity.resources.extra }}
+              {{- with .Values.capacity.resources }}
               {{- toYaml . | nindent 14 }}
               {{- end }}
       {{- with .Values.pause.nodeSelector }}

--- a/charts/overprovisioner/templates/pause/deployment.yaml
+++ b/charts/overprovisioner/templates/pause/deployment.yaml
@@ -54,9 +54,15 @@ spec:
             requests:
               cpu: {{ .Values.capacity.resources.cpu }}
               memory: {{ .Values.capacity.resources.memory }}
+              {{- with .Values.capacity.resources.extra }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
             limits:
               cpu: {{ .Values.capacity.resources.cpu }}
               memory: {{ .Values.capacity.resources.memory }}
+              {{- with .Values.capacity.resources.extra }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
       {{- with .Values.pause.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/overprovisioner/values.yaml
+++ b/charts/overprovisioner/values.yaml
@@ -9,10 +9,10 @@ nameOverride:
 fullnameOverride:
 
 # -- Labels to add to all chart resources.
-commonLabels: {}
+commonLabels: { }
 
 # -- Image pull secrets.
-imagePullSecrets: []
+imagePullSecrets: [ ]
 
 capacity:
   # -- Capacity mode to use; one of `fixed` or `auto`. If `auto` is used, a [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) deployment will be used to scale the pause pods
@@ -37,6 +37,7 @@ capacity:
     cpu: 10m
     # -- Memory resource requests and limits for the pause pods.
     memory: 16Mi
+    extra: {}
 
 priorityClass:
   # -- If `true`, create a new preemptible `PriorityClass`.
@@ -44,9 +45,9 @@ priorityClass:
   # -- (string) If this is set and `priorityClass.create` is `true` this will be used for the created priority class name, if set and `priorityClass.create` is `false` then this will define an existing priority class to use.
   name:
   # -- Labels to add to the priority class.
-  labels: {}
+  labels: { }
   # -- Annotations to add to the priority class.
-  annotations: {}
+  annotations: { }
   # -- Value for the priority class.
   value: -1
 
@@ -57,15 +58,15 @@ pause:
     # -- (string) If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Pause_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use.
     name:
     # -- Labels to add to the _Pause_ service account.
-    labels: {}
+    labels: { }
     # -- Annotations to add to the _Pause_ service account.
-    annotations: {}
+    annotations: { }
 
   # -- Labels to add to the _Pause_ pod.
-  podLabels: {}
+  podLabels: { }
 
   # -- Annotations to add to the _Pause_ pod.
-  podAnnotations: {}
+  podAnnotations: { }
 
   image:
     # -- Image repository for the _Pause_ component default container.
@@ -76,16 +77,16 @@ pause:
     pullPolicy: IfNotPresent
 
   # -- Node selector labels for scheduling the _Pause_ component.
-  nodeSelector: {}
+  nodeSelector: { }
 
   # -- Affinity settings for scheduling the _Pause_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
-  affinity: {}
+  affinity: { }
 
   # -- Topology spread constraints for scheduling for the _Pause_ component. If an explicit label selector is not provided one will be created from the pod selector labels.
-  topologySpreadConstraints: []
+  topologySpreadConstraints: [ ]
 
   # -- Node taints the _Pause_ component will tolerate for scheduling.
-  tolerations: []
+  tolerations: [ ]
 
 autoscaler:
   serviceAccount:
@@ -94,15 +95,15 @@ autoscaler:
     # -- (string) If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Autoscaler_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use.
     name:
     # -- Labels to add to the _Autoscaler_ service account.
-    labels: {}
+    labels: { }
     # -- Annotations to add to the _Autoscaler_ service account.
-    annotations: {}
+    annotations: { }
 
   # -- Labels to add to the _Autoscaler_ pod.
-  podLabels: {}
+  podLabels: { }
 
   # -- Annotations to add to the _Autoscaler_ pod.
-  podAnnotations: {}
+  podAnnotations: { }
 
   # -- Security context for the _Autoscaler_ pod.
   # @default -- See _values.yaml_
@@ -140,19 +141,19 @@ autoscaler:
         - ALL
 
   # -- Resources for the _Autoscaler_ component default container.
-  resources: {}
+  resources: { }
 
   # -- Node selector labels for scheduling the _Autoscaler_ component.
-  nodeSelector: {}
+  nodeSelector: { }
 
   # -- Affinity settings for scheduling the _Autoscaler_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
-  affinity: {}
+  affinity: { }
 
   # -- Topology spread constraints for scheduling for the _Autoscaler_ component. If an explicit label selector is not provided one will be created from the pod selector labels.
-  topologySpreadConstraints: []
+  topologySpreadConstraints: [ ]
 
   # -- Node taints the _Autoscaler_ component will tolerate for scheduling.
-  tolerations: []
+  tolerations: [ ]
 
   # -- Log level for the _Autoscaler_ component.
   logLevel: 2

--- a/charts/overprovisioner/values.yaml
+++ b/charts/overprovisioner/values.yaml
@@ -37,7 +37,6 @@ capacity:
     cpu: 10m
     # -- Memory resource requests and limits for the pause pods.
     memory: 16Mi
-    extra: {}
 
 priorityClass:
   # -- If `true`, create a new preemptible `PriorityClass`.

--- a/charts/overprovisioner/values.yaml
+++ b/charts/overprovisioner/values.yaml
@@ -33,7 +33,10 @@ capacity:
     maxReplicas: 1
 
   # -- map of resources
-  resources: {}
+  # @default -- See _values.yaml_
+  resources:
+    cpu: 10m
+    memory: 16Mi
 
 priorityClass:
   # -- If `true`, create a new preemptible `PriorityClass`.

--- a/charts/overprovisioner/values.yaml
+++ b/charts/overprovisioner/values.yaml
@@ -9,10 +9,10 @@ nameOverride:
 fullnameOverride:
 
 # -- Labels to add to all chart resources.
-commonLabels: { }
+commonLabels: {}
 
 # -- Image pull secrets.
-imagePullSecrets: [ ]
+imagePullSecrets: []
 
 capacity:
   # -- Capacity mode to use; one of `fixed` or `auto`. If `auto` is used, a [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) deployment will be used to scale the pause pods
@@ -45,9 +45,9 @@ priorityClass:
   # -- (string) If this is set and `priorityClass.create` is `true` this will be used for the created priority class name, if set and `priorityClass.create` is `false` then this will define an existing priority class to use.
   name:
   # -- Labels to add to the priority class.
-  labels: { }
+  labels: {}
   # -- Annotations to add to the priority class.
-  annotations: { }
+  annotations: {}
   # -- Value for the priority class.
   value: -1
 
@@ -58,15 +58,15 @@ pause:
     # -- (string) If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Pause_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use.
     name:
     # -- Labels to add to the _Pause_ service account.
-    labels: { }
+    labels: {}
     # -- Annotations to add to the _Pause_ service account.
-    annotations: { }
+    annotations: {}
 
   # -- Labels to add to the _Pause_ pod.
-  podLabels: { }
+  podLabels: {}
 
   # -- Annotations to add to the _Pause_ pod.
-  podAnnotations: { }
+  podAnnotations: {}
 
   image:
     # -- Image repository for the _Pause_ component default container.
@@ -77,16 +77,16 @@ pause:
     pullPolicy: IfNotPresent
 
   # -- Node selector labels for scheduling the _Pause_ component.
-  nodeSelector: { }
+  nodeSelector: {}
 
   # -- Affinity settings for scheduling the _Pause_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
-  affinity: { }
+  affinity: {}
 
   # -- Topology spread constraints for scheduling for the _Pause_ component. If an explicit label selector is not provided one will be created from the pod selector labels.
-  topologySpreadConstraints: [ ]
+  topologySpreadConstraints: []
 
   # -- Node taints the _Pause_ component will tolerate for scheduling.
-  tolerations: [ ]
+  tolerations: []
 
 autoscaler:
   serviceAccount:
@@ -95,15 +95,15 @@ autoscaler:
     # -- (string) If this is set and `pause.serviceAccount.create` is `true` this will be used for the created _Autoscaler_ service account name, if this is set and `pause.serviceAccount.create` is `false` then this will define an existing service account to use.
     name:
     # -- Labels to add to the _Autoscaler_ service account.
-    labels: { }
+    labels: {}
     # -- Annotations to add to the _Autoscaler_ service account.
-    annotations: { }
+    annotations: {}
 
   # -- Labels to add to the _Autoscaler_ pod.
-  podLabels: { }
+  podLabels: {}
 
   # -- Annotations to add to the _Autoscaler_ pod.
-  podAnnotations: { }
+  podAnnotations: {}
 
   # -- Security context for the _Autoscaler_ pod.
   # @default -- See _values.yaml_
@@ -141,19 +141,19 @@ autoscaler:
         - ALL
 
   # -- Resources for the _Autoscaler_ component default container.
-  resources: { }
+  resources: {}
 
   # -- Node selector labels for scheduling the _Autoscaler_ component.
-  nodeSelector: { }
+  nodeSelector: {}
 
   # -- Affinity settings for scheduling the _Autoscaler_ component. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
-  affinity: { }
+  affinity: {}
 
   # -- Topology spread constraints for scheduling for the _Autoscaler_ component. If an explicit label selector is not provided one will be created from the pod selector labels.
-  topologySpreadConstraints: [ ]
+  topologySpreadConstraints: []
 
   # -- Node taints the _Autoscaler_ component will tolerate for scheduling.
-  tolerations: [ ]
+  tolerations: []
 
   # -- Log level for the _Autoscaler_ component.
   logLevel: 2

--- a/charts/overprovisioner/values.yaml
+++ b/charts/overprovisioner/values.yaml
@@ -32,7 +32,7 @@ capacity:
     # -- Maximum number of pause pod replicas to create; if `capacity.mode` is `auto`.
     maxReplicas: 1
 
-  # -- map of resources
+  # -- (object) Map of resources to provision.
   # @default -- See _values.yaml_
   resources:
     cpu: 10m

--- a/charts/overprovisioner/values.yaml
+++ b/charts/overprovisioner/values.yaml
@@ -32,11 +32,8 @@ capacity:
     # -- Maximum number of pause pod replicas to create; if `capacity.mode` is `auto`.
     maxReplicas: 1
 
-  resources:
-    # -- CPU resource requests and limits for the pause pods.
-    cpu: 10m
-    # -- Memory resource requests and limits for the pause pods.
-    memory: 16Mi
+  # -- map of resources
+  resources: {}
 
 priorityClass:
   # -- If `true`, create a new preemptible `PriorityClass`.


### PR DESCRIPTION
Current helm chart only supports `cpu` and `memory`, so I would like to add extra field
For example, I need to add below values

``` resources:
            requests:
              cpu: 10m
              memory: 16Mi
              nvidia.com/gpu: "1"
```

To support the above values, I added `resources.extra` field

Closes #901.