### PR TITLE
fix(nexus3): fix \ in password, during sed and curl

### DIFF
--- a/charts/nexus3/files/configure.sh
+++ b/charts/nexus3/files/configure.sh
@@ -144,7 +144,7 @@ do
 
     if [[ -f "${base_dir}/secret/ldap.password" ]]
     then
-      ldap_password=$(cat "${base_dir}/secret/ldap.password" | sed 's|"|\\"|g;s|/|\\/|g;s|\\|\\\\|g')
+      ldap_password=$(cat "${base_dir}/secret/ldap.password" | sed 's|"|\\"|g;s|/|\\/|g;s|\\|\\\\\\\\|g')
       sed -i "s/PASSWORD/${ldap_password}/g" "${json_file}"
     fi
 


### PR DESCRIPTION
This PR fix a problem with `\` character, during sed and curl. Actually, I've this error during injection:

My password example: `9Ew0Zk5$20,5\^^xkS3`

```text
Updating user 'anonymous'...
User configured.
Configuring anonymous user...
Anonymous user configured.
Updating LDAP configuration for 'ldap'...
2024-03-13 09:27:46,665+0000 WARN  [qtp1152171967-112] admin org.sonatype.nexus.siesta.internal.JsonMappingExceptionMapper - (ID abaf052a-7f97-4e24-a8d9-f213b1728e6a) Response: [400] '[ValidationErrorXO{id='authPassword', message='Unrecognized character escape '^' (code 94)'}]'; mapped from: com.fasterxml.jackson.databind.JsonMappingException: Unrecognized character escape '^' (code 94)
 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 76] (through reference chain: org.sonatype.nexus.ldap.model.UpdateLdapServerXo["authPassword"])
ERROR: Could not configure LDAP.
```