### PR TITLE
feat(nexus3): added service.additionalPorts.hosts for multi-hosts support

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -14,6 +14,14 @@
 
 ## [UNRELEASED]
 
+### Added
+
+- Added `service.additionalPorts.hosts` (list) for multi-hosts support
+
+### Deprecated
+
+- Deprecated `service.additionalPorts.host` in favour of `service.additionalPorts.hosts`
+
 ## [v4.44.0] - 2024-06-10
 
 ### Changed

--- a/charts/nexus3/ci/ci-values.yaml
+++ b/charts/nexus3/ci/ci-values.yaml
@@ -96,4 +96,13 @@ config:
       attributes:
         blobStoreName: "default"
 
+service:
+  additionalPorts:
+    - port: 8083
+      name: docker-hosted
+      containerPort: 8083
+      hosts:
+        - nexus-docker-hosted-1.local
+        - nexus-docker-hosted-2.local
+
 testResources: true

--- a/charts/nexus3/ci/kubeconform.yaml
+++ b/charts/nexus3/ci/kubeconform.yaml
@@ -24,11 +24,14 @@ service:
     - port: 8082
       name: docker-group
       containerPort: 8082
-      host: nexus-docker.local
+      hosts:
+        - nexus-docker.local
     - port: 8083
       name: docker-hosted
       containerPort: 8083
-      host: nexus-docker-hosted.local
+      hosts:
+        - nexus-docker-hosted-1.local
+        - nexus-docker-hosted-2.local
 
 metrics:
   enabled: true
@@ -50,7 +53,8 @@ ingress:
     - hosts:
         - nexus.local
         - nexus-docker.local
-        - nexus-docker-hosted.local
+        - nexus-docker-hosted-1.local
+        - nexus-docker-hosted-2.local
       secretName: nexus3-local-tls
 
 persistence:

--- a/charts/nexus3/templates/ingress.yaml
+++ b/charts/nexus3/templates/ingress.yaml
@@ -37,8 +37,9 @@ spec:
               servicePort: http
             {{- end }}
   {{- end }}
-  {{- range .Values.service.additionalPorts }}
-    - host: {{ .host | quote }}
+  {{- range $additionalPort := .Values.service.additionalPorts }}
+  {{- range ternary $additionalPort.hosts (list $additionalPort.host) (empty $additionalPort.host) }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: /
@@ -50,11 +51,12 @@ spec:
               service:
                 name: {{ $serviceName }}
                 port:
-                  name: {{ .name }}
+                  name: {{ $additionalPort.name }}
             {{- else }}
               serviceName: {{ $serviceName }}
-              servicePort: {{ .name }}
+              servicePort: {{ $additionalPort.name }}
             {{- end }}
+  {{- end }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/nexus3/values.yaml
+++ b/charts/nexus3/values.yaml
@@ -71,11 +71,14 @@ service:
   #   - port: 8082
   #     name: docker-group
   #     containerPort: 8082
-  #     host: nexus-docker.local
+  #     hosts:
+  #       - nexus-docker.local
   #   - port: 8083
   #     name: docker-hosted
   #     containerPort: 8083
-  #     host: nexus-docker-hosted.local
+  #     hosts:
+  #       - nexus-docker-hosted-1.local
+  #       - nexus-docker-hosted-2.local
 
 metrics:
   enabled: false
@@ -95,7 +98,8 @@ ingress:
   #   - hosts:
   #       - nexus.local
   #       - nexus-docker.local
-  #       - nexus-docker-hosted.local
+  #       - nexus-docker-hosted-1.local
+  #       - nexus-docker-hosted-2.local
   #     secretName: nexus-local-tls
 
 persistence:


### PR DESCRIPTION
Added `service.additionalPorts.hosts` for multi-hosts support.

By example:

```yaml
  additionalPorts:
     - port: 8082
       name: docker-group
       containerPort: 8082
       hosts:
         - nexus-docker.local
     - port: 8083
       name: docker-hosted
       containerPort: 8083
       hosts:
         - nexus-docker-hosted-1.local
         - nexus-docker-hosted-2.local
```

Also `service.additionalPorts.host` is now deprecated.