### PR TITLE
Include Registry for Init Containers in Nexus Helm Chart

### DIFF
--- a/charts/nexus3/templates/NOTES.txt
+++ b/charts/nexus3/templates/NOTES.txt
@@ -3,5 +3,5 @@
 ***********************************************************************
   Chart version: {{ .Chart.Version }}
   App version:   {{ .Chart.AppVersion }}
-  Image tag:     {{ include "nexus3.image" . }}
+  Image tag:     {{ include "nexus3.image" (list .Values.global .Values) }}
 ***********************************************************************

--- a/charts/nexus3/templates/_helpers.tpl
+++ b/charts/nexus3/templates/_helpers.tpl
@@ -68,8 +68,16 @@ Create the name of the service account to use
 {{/*
 The image to use
 */}}
-{{- define "nexus3.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default (printf "%s-java11" .Chart.AppVersion) .Values.image.tag) }}
+{{- define "nexus3.image" }}
+   {{- $globalValues := index . 0 -}}
+   {{- $componentValues := index . 1 -}}
+   {{- if $componentValues.image.registry -}}
+   {{- printf "%s/%s:%v" $componentValues.image.registry $componentValues.image.repository  $componentValues.image.tag -}}
+   {{- else if $globalValues.image.registry -}}
+   {{- printf "%s/%s:%v" $globalValues.image.registry $componentValues.image.repository  $componentValues.image.tag -}}
+   {{- else -}}
+   {{- printf "%s:%v" $componentValues.image.repository  $componentValues.image.tag -}}
+   {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/nexus3/templates/deployment.yaml
+++ b/charts/nexus3/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
       {{- if .Values.caCerts.enabled }}
         - name: ca-certs
-          image: adoptopenjdk:8-jdk-hotspot
+          image: {{- include "nexus3.image" (list .Values.global .Values.caCerts)}}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       {{- if .Values.plugins }}
         - name: download-plugins
-          image: alpine:3
+          image: {{ include "nexus3.image" (list .Values.global .Values.plugins) }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -69,7 +69,7 @@ spec:
           args:
             - -c
             - |
-          {{- range .Values.plugins }}
+          {{- range .Values.plugins.pluginsList }}
               wget -O /deploy/{{ .name }}.kar {{ .url }}
           {{- end }}
           volumeMounts:
@@ -79,9 +79,9 @@ spec:
       {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.chownDataDir }}
+      {{- if .Values.chownDataDir.enabled }}
         - name: volume-mount
-          image: alpine:3
+          image: {{ include "nexus3.image" (list .Values.global .Values.chownDataDir)}}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -99,7 +99,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: {{ include "nexus3.image" . }}
+          image: {{ include "nexus3.image" (list .Values.global .Values) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           {{- with .Values.env }}

--- a/charts/nexus3/values.yaml
+++ b/charts/nexus3/values.yaml
@@ -5,7 +5,6 @@ global:
 image:
   registry: ""
   repository: sonatype/nexus3
-  # Overrides the image tag whose default is {{ .Chart.AppVersion }}
   tag: "4.44.0-java11"
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/charts/nexus3/values.yaml
+++ b/charts/nexus3/values.yaml
@@ -131,7 +131,6 @@ resources: {}
 chownDataDir:
   enabled: true
   image:
-    registry: sonatype
     repository: alpine
     tag: 3
 
@@ -184,7 +183,7 @@ storeProperties: []
 plugins:
   image:
     repository: alpine
-    tag: 3.2.1
+    tag: 3
   pluginsList: []
 #   - name: nexus-repository-composer
 #     url: https://repo1.maven.org/maven2/org/sonatype/nexus/plugins/nexus-repository-composer/0.0.29/nexus-repository-composer-0.0.29-bundle.kar

--- a/charts/nexus3/values.yaml
+++ b/charts/nexus3/values.yaml
@@ -1,7 +1,12 @@
+global:
+  image:
+    registry: ""
+
 image:
+  registry: ""
   repository: sonatype/nexus3
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  tag: ""
+  tag: "4.44.0-java11"
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -124,7 +129,12 @@ resources: {}
 #     cpu: 100m
 #     memory: 128Mi
 
-chownDataDir: true
+chownDataDir:
+  enabled: true
+  image:
+    registry: sonatype
+    repository: alpine
+    tag: 3
 
 extraInitContainers: []
 
@@ -142,6 +152,9 @@ tolerations: []
 
 caCerts:
   enabled: false
+  image:
+    repository: adoptopenjdk
+    tag: 8-jdk-hotspot
   secret:
 
 # if secret is provided, the license will be configured via properties, otherwise a license can still be entered manually via UI
@@ -169,7 +182,11 @@ properties:
 
 storeProperties: []
 
-plugins: []
+plugins:
+  image:
+    repository: alpine
+    tag: 3.2.1
+  pluginsList: []
 #   - name: nexus-repository-composer
 #     url: https://repo1.maven.org/maven2/org/sonatype/nexus/plugins/nexus-repository-composer/0.0.29/nexus-repository-composer-0.0.29-bundle.kar
 


### PR DESCRIPTION
This pull request enhances the Sonatype Nexus Helm Chart by allowing users to specify their own container image registry for both the main containers and the init containers.

At our organization, it is essential to pull images from our own repository, including the init containers. However, the existing Helm Chart did not support this functionality, resulting in a limitation for our deployment.

To address this issue, I have updated the Helm Chart to include the ability to specify the registry for init containers. This update provides users with the flexibility to utilize their preferred registry for all containers within the Nexus deployment.