### PR TITLE
Fix ldap config missing argument bug

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fix ldap config missing argument
+
 ## [v5.1.0] - 2024-10-14
 
 ### Changed

--- a/charts/nexus3/templates/configmap-config.yaml
+++ b/charts/nexus3/templates/configmap-config.yaml
@@ -30,7 +30,7 @@ data:
 {{- if .Values.config.ldap.enabled }}
   ldap.json: |
 {{- with omit .Values.config.ldap "enabled" "authPassword" }}
-    {{-  toJson | nindent 4 }}
+    {{-  toJson . | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- range $index, $blobStore := .Values.config.blobStores }}


### PR DESCRIPTION
I have fixed the ldap configuration error in latest release.

```
Error: template: nexus3/templates/job-config.yaml:16:28: executing "nexus3/templates/job-config.yaml" at <include (print $.Template.BasePath "/configmap-config.yaml") .>: error calling include: template: nexus3/templates/configmap-config.yaml:33:9: executing "nexus3/templates/configmap-config.yaml" at <toJson>: wrong number of args for toJson: want 1 got 0
```

Please review it and release a new helm chart version when you available.
Thanks