### PR TITLE
Change default lease name for vpa-recommender to "vpa-recommender-lease" to avoid conflicts

### DIFF
--- a/charts/vertical-pod-autoscaler/templates/rbac.yaml
+++ b/charts/vertical-pod-autoscaler/templates/rbac.yaml
@@ -446,7 +446,8 @@ rules:
   - apiGroups:
       - coordination.k8s.io
     resourceNames:
-      - vpa-recommender
+      - vpa-recommender  # kept here for historical reasons
+      - vpa-recommender-lease
     resources:
       - leases
     verbs:


### PR DESCRIPTION
See kubernetes/autoscaler#7461.

The default lock name can sometimes conflict with a managed deployment of VPA/HPA which can cause issues on your cluster.

Here we are proposing changing the flag value in the Helm chart to a new name (`vpa-recommender-lease`). We are keeping the old resource name in the RBAC to avoid disruptions or issues during upgrade.