### PR TITLE
fix cert-manager injection target

### DIFF
--- a/charts/vertical-pod-autoscaler/CHANGELOG.md
+++ b/charts/vertical-pod-autoscaler/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- Fixed incorrect cert-manager ca-injection target in mutatingwebhookconfiguration
+- Fixed incorrect cert-manager ca-injection target in mutatingwebhookconfiguration. ([#1106](https://github.com/stevehipwell/helm-charts/pull/1106)) _@PaulFarver_
 
 ## [v1.7.1] - 2024-08-22
 

--- a/charts/vertical-pod-autoscaler/CHANGELOG.md
+++ b/charts/vertical-pod-autoscaler/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed incorrect cert-manager ca-injection target in mutatingwebhookconfiguration
+
 ## [v1.7.1] - 2024-08-22
 
 ### Added

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/webhook.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/webhook.yaml
@@ -23,7 +23,7 @@ metadata:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
   {{- if .Values.admissionController.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "vertical-pod-autoscaler.admissionController.webhookCertSecret" .) }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "vertical-pod-autoscaler.admissionController.fullname" .) }}
   {{- end }}
 webhooks:
   - name: vpa.k8s.io


### PR DESCRIPTION
@stevehipwell thanks for maintaining this chart 🎉 

When running with `.Values.admissionController.certManager.enabled` we get the following error in our cert-manager-cainjector:

```
...
E0108 10:48:13.701446       1 sources.go:106] "unable to fetch associated certificate" err="Certificate.cert-manager.io \"vertical-pod-autoscaler-admission-controller-cert\" not found" logger="cert-manager" kind="mutatingwebhookconfiguration" kind="mutatingwebhookconfiguration" name="vpa-webhook-config" certificate="vertical-pod-autoscaler/vertical-pod-autoscaler-admission-controller-cert"
I0108 10:48:13.701486       1 reconciler.go:117] "could not find any ca data in data source for target" logger="cert-manager" kind="mutatingwebhookconfiguration" kind="mutatingwebhookconfiguration" name="vpa-webhook-config"
```

Taking a look at the templates, it looks like the annotation expects a reference to a certificate, but gets a reference to a secret. We can fix that with the following, based on the documentation here: https://cert-manager.io/docs/concepts/ca-injector/#injecting-ca-data-from-a-secret-resource