### PR TITLE
Set source: default when not defined

### DIFF
--- a/charts/nexus3/scripts/configure.sh
+++ b/charts/nexus3/scripts/configure.sh
@@ -161,6 +161,7 @@ for json_file in "${CONFIG_DIR}"/conf/*-role.json; do
   if [[ -f "${json_file}" ]]; then
     id="$(jq -r '.id' "${json_file}")"
     source="$(jq -r '.source' "${json_file}")"
+    source=${source/null/default}
 
     status_code=$(curl -sS -o /dev/null -w "%{http_code}" -X GET -H 'Content-Type: application/json' -u "${NEXUS_USER}:${password}" "${NEXUS_HOST}/service/rest/v1/security/roles/${id}?source=${source}")
     if [[ "${status_code}" -eq 200 ]]; then
@@ -184,6 +185,7 @@ for json_file in "${CONFIG_DIR}"/conf/*-user.json; do
   if [[ -f "${json_file}" ]]; then
     id="$(jq -r '.userId' "${json_file}")"
     source="$(jq -r '.source' "${json_file}")"
+    source=${source/null/default}
 
     out_file="$(mktemp -p "${tmp_dir}")"
     status_code=$(curl -sS -o "${out_file}" -w "%{http_code}" -X GET -H 'Content-Type: application/json' -u "${NEXUS_USER}:${password}" "${NEXUS_HOST}/service/rest/v1/security/users/?userId=${id}&source=${source}")


### PR DESCRIPTION
This PR sets `source: default` when not defined. Prevents confusion when upgrading entities. Reference #1059 1059