### PR TITLE
WIP: [Plantuml] Make jetty home writeable by copying it to emptydir volume

### DIFF
--- a/charts/plantuml/templates/deployment.yaml
+++ b/charts/plantuml/templates/deployment.yaml
@@ -39,8 +39,24 @@ spec:
       {{- with .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
-      {{- if .Values.caCerts.enabled }}
       initContainers:
+        - name: plantuml-init
+          image: {{ include "plantuml.image" . }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: jettyhome
+              mountPath: /jettyhome
+          command: [sh, -cx]
+          args:
+            - >-
+              echo Copying Jetty home to volume;
+              ls -l /usr/local/jetty;
+              cp -r /usr/local/jetty/. /jettyhome/
+      {{- if .Values.caCerts.enabled }}
         - name: ca-certs
           image: adoptopenjdk:11-jdk-hotspot
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -93,6 +109,8 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: jettyhome
+              mountPath: /usr/local/jetty
           {{- if .Values.caCerts.enabled }}
             - name: ca-certs-keystore
               mountPath: /usr/local/openjdk-11/lib/security/cacerts
@@ -104,6 +122,8 @@ spec:
           {{- end }}
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: jettyhome
           emptyDir: {}
       {{- if .Values.caCerts.enabled }}
         - name: ca-certs-secret


### PR DESCRIPTION
We had an issue with error logs for: ` Could not lock User prefs.  Unix error code 2`

It seems to come from jetty home (`/usr/local/jetty`) not beeing writeable, copying jetty home to an emptydir seems to solve the issue for us, so providing patch for this.