### PR TITLE
fix(vertical-pod-autoscaler): Update secretName for the TLS cert mount

### DIFF
--- a/charts/vertical-pod-autoscaler/CHANGELOG.md
+++ b/charts/vertical-pod-autoscaler/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## [UNRELEASED]
 
+## [v1.8.1] - 2025-03-10
+
+### Fixed
+
+- Fixed the name of the secret mounted for TLS certificates when using a custom Issuer with cert-manager. ([#1140](https://github.com/stevehipwell/helm-charts/issues/1140)) _@ahamlinman_
+
 ## [v1.8.0] - 2025-02-14
 
 ### Added
@@ -126,6 +132,7 @@
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/stevehipwell/helm-charts/tree/main/charts/vertical-pod-autoscaler
+[v1.8.1]: https://github.com/stevehipwell/helm-charts/releases/tag/vertical-pod-autoscaler-1.8.1
 [v1.8.0]: https://github.com/stevehipwell/helm-charts/releases/tag/vertical-pod-autoscaler-1.8.0
 [v1.7.3]: https://github.com/stevehipwell/helm-charts/releases/tag/vertical-pod-autoscaler-1.7.3
 [v1.7.2]: https://github.com/stevehipwell/helm-charts/releases/tag/vertical-pod-autoscaler-1.7.2

--- a/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/charts/vertical-pod-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vertical-pod-autoscaler
 description: Helm chart for the Vertical Pod Autoscaler.
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: 1.3.0
 keywords:
   - kubernetes

--- a/charts/vertical-pod-autoscaler/README.md
+++ b/charts/vertical-pod-autoscaler/README.md
@@ -1,6 +1,6 @@
 # vertical-pod-autoscaler
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 The [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/) (VPA) frees the users from necessity of setting up-to-date resource limits and requests for the containers in their pods. When configured, it will set the requests automatically based on usage and thus allow proper scheduling onto nodes so that appropriate resource amount is available for each pod. It will also maintain ratios between limits and requests that were specified in initial containers configuration.
 
@@ -33,7 +33,7 @@ This chart manages the `MutatingWebhookConfiguration` outside of the workload so
 To install the chart using the recommended OCI method you can use the following command.
 
 ```shell
-helm upgrade --install vertical-pod-autoscaler oci://ghcr.io/stevehipwell/helm-charts/vertical-pod-autoscaler --version 1.8.0
+helm upgrade --install vertical-pod-autoscaler oci://ghcr.io/stevehipwell/helm-charts/vertical-pod-autoscaler --version 1.8.1
 ```
 
 #### Verification
@@ -41,7 +41,7 @@ helm upgrade --install vertical-pod-autoscaler oci://ghcr.io/stevehipwell/helm-c
 As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
 
 ```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository stevehipwell/helm-charts --certificate-github-workflow-name Release ghcr.io/stevehipwell/helm-charts/vertical-pod-autoscaler:1.8.0
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository stevehipwell/helm-charts --certificate-github-workflow-name Release ghcr.io/stevehipwell/helm-charts/vertical-pod-autoscaler:1.8.1
 ```
 
 ### Non-OCI Repository
@@ -50,7 +50,7 @@ Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add stevehipwell https://stevehipwell.github.io/helm-charts/
-helm upgrade --install vertical-pod-autoscaler stevehipwell/vertical-pod-autoscaler --version 1.8.0
+helm upgrade --install vertical-pod-autoscaler stevehipwell/vertical-pod-autoscaler --version 1.8.1
 ```
 
 ## Values

--- a/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -91,7 +91,7 @@ spec:
       volumes:
         - name: tls-certs
           secret:
-            secretName: {{ include "vertical-pod-autoscaler.admissionController.webhookCertIssuerName" . }}
+            secretName: {{ include "vertical-pod-autoscaler.admissionController.webhookCertSecret" . }}
       {{- with .Values.admissionController.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
When a custom issuer is used, the secret name and issuer name are no longer guaranteed to align. Fixes #1137.

## Testing

I've tried deploying this internally, and it turns out our normal `ClusterIssuer` requires a common name on every certificate, which I'll have to look into separately. In the meantime, I have some sample commands to show off the diff between the chart versions.

### Enabling cert-manager with the default issuer

```sh
git checkout main && \
  helm template vertical-pod-autoscaler ./charts/vertical-pod-autoscaler \
  --set admissionController.certManager.enabled=true \
  > old.yaml
git checkout vpa-custom-issuer-secret-name && \
  helm template vertical-pod-autoscaler ./charts/vertical-pod-autoscaler \
  --set admissionController.certManager.enabled=true \
  > new.yaml
diff -u old.yaml new.yaml
```

…produces no output, as expected.

### Enabling cert-manager with a custom issuer

```sh
git checkout main && \
  helm template vertical-pod-autoscaler ./charts/vertical-pod-autoscaler \
  --set admissionController.certManager.enabled=true \
  --set admissionController.certManager.issuerName=my-custom-issuer \
  > old.yaml
git checkout vpa-custom-issuer-secret-name && \
  helm template vertical-pod-autoscaler ./charts/vertical-pod-autoscaler \
  --set admissionController.certManager.enabled=true \
  --set admissionController.certManager.issuerName=my-custom-issuer \
  > new.yaml
diff -u old.yaml new.yaml
```

…produces the following:

```diff
--- old.yaml    2025-03-04 11:35:46
+++ new.yaml    2025-03-04 11:35:53
@@ -619,7 +619,7 @@
       volumes:
         - name: tls-certs
           secret:
-            secretName: my-custom-issuer
+            secretName: vertical-pod-autoscaler-admission-controller-cert
 ---
 # Source: vertical-pod-autoscaler/templates/recommender/deployment.yaml
 apiVersion: apps/v1
```

…which matches what `grep -A20 'kind: Certificate' new.yaml` shows is the certificate name:

```yaml
kind: Certificate
metadata:
  name: vertical-pod-autoscaler-admission-controller
# ...
  issuerRef:
    kind: Issuer
    name: my-custom-issuer
  secretName: vertical-pod-autoscaler-admission-controller-cert
```

## Release

I can cut a separate PR for a v1.8.1 release (similar to how #1111 released a fix for this chart from #1106), or if it would be easier I'm happy to inline those bumps into this PR.