### PR TITLE
fix: kube-proxy.image produces unwanted output

### DIFF
--- a/charts/kube-proxy/CHANGELOG.md
+++ b/charts/kube-proxy/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## [UNRELEASED]
 
+## [v0.0.8] - 2025-04-01
+
+### Fixed
+
+- Fixed validation/unwanted output in kube-proxy.image include  ([#1156](https://github.com/stevehipwell/helm-charts/pull/1156)) _@robertoriv_
+
 ## [v0.0.7] - 2025-03-18
 
 ### Changed

--- a/charts/kube-proxy/Chart.yaml
+++ b/charts/kube-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kube-proxy
 description: Helm chart for managing kube-proxy.
 type: application
-version: 0.0.7
-appVersion: 0.0.7
+version: 0.0.8
+appVersion: 0.0.8
 keywords:
   - kubernetes
   - kube-proxy

--- a/charts/kube-proxy/README.md
+++ b/charts/kube-proxy/README.md
@@ -1,6 +1,6 @@
 # kube-proxy
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.7](https://img.shields.io/badge/AppVersion-0.0.7-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.8](https://img.shields.io/badge/AppVersion-0.0.8-informational?style=flat-square)
 
 Helm chart for managing kube-proxy.
 
@@ -24,7 +24,7 @@ Helm chart for managing kube-proxy.
 To install the chart using the recommended OCI method you can use the following command.
 
 ```shell
-helm upgrade --install kube-proxy oci://ghcr.io/stevehipwell/helm-charts/kube-proxy --version 0.0.7
+helm upgrade --install kube-proxy oci://ghcr.io/stevehipwell/helm-charts/kube-proxy --version 0.0.8
 ```
 
 #### Verification
@@ -32,7 +32,7 @@ helm upgrade --install kube-proxy oci://ghcr.io/stevehipwell/helm-charts/kube-pr
 As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
 
 ```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository stevehipwell/helm-charts --certificate-github-workflow-name Release ghcr.io/stevehipwell/helm-charts/kube-proxy:0.0.7
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository stevehipwell/helm-charts --certificate-github-workflow-name Release ghcr.io/stevehipwell/helm-charts/kube-proxy:0.0.8
 ```
 
 ### Non-OCI Repository
@@ -41,7 +41,7 @@ Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add stevehipwell https://stevehipwell.github.io/helm-charts/
-helm upgrade --install kube-proxy stevehipwell/kube-proxy --version 0.0.7
+helm upgrade --install kube-proxy stevehipwell/kube-proxy --version 0.0.8
 ```
 
 ## Values

--- a/charts/kube-proxy/templates/_helpers.tpl
+++ b/charts/kube-proxy/templates/_helpers.tpl
@@ -74,6 +74,8 @@ The image to use
 {{- define "kube-proxy.image" -}}
 {{- $tag := ternary (printf ":%s" .Values.image.tag) "" (not (empty .Values.image.tag)) }}
 {{- $digest := ternary (printf "@%s" .Values.image.digest) "" (not (empty .Values.image.digest)) }}
-{{- required "At least one of image.tag or image.digest must be provided" (default $tag $digest) }}
+{{- if and (empty $tag) (empty $digest) }}
+  {{- fail "At least one of image.tag or image.digest must be provided" }}
+{{- end }}
 {{- printf "%s%s%s" .Values.image.repository $tag $digest }}
 {{- end }}

--- a/charts/kube-proxy/templates/_helpers.tpl
+++ b/charts/kube-proxy/templates/_helpers.tpl
@@ -75,7 +75,7 @@ The image to use
 {{- $tag := ternary (printf ":%s" .Values.image.tag) "" (not (empty .Values.image.tag)) }}
 {{- $digest := ternary (printf "@%s" .Values.image.digest) "" (not (empty .Values.image.digest)) }}
 {{- if and (empty $tag) (empty $digest) }}
-  {{- fail "At least one of image.tag or image.digest must be provided" }}
+{{- fail "At least one of image.tag or image.digest must be provided" }}
 {{- end }}
 {{- printf "%s%s%s" .Values.image.repository $tag $digest }}
 {{- end }}


### PR DESCRIPTION
I was trying out the `kube-proxy` chart and noticed that the `kube-proxy.image` include was prepending the tag value before the repository.

```
❯ cat example.yaml
image:
  repository: myrepository.com/kube-proxy
  tag: v1.0.0

apiServer:
  endpoint: https://myapiserver.com

❯ helm template . -f example.yaml | grep "image:"
          image: :v1.0.0myrepository.com/kube-proxy:v1.0.0
          image: :v1.0.0myrepository.com/kube-proxy:v1.0.0
```

The proposed change retains the check so that one of `tag` or `digest` is set, but doesn't produce the bad output.

Test with tag:
```
❯ cat example.yaml
image:
  repository: myrepository.com/kube-proxy
  tag: v1.0.0

apiServer:
  endpoint: https://myapiserver.com

❯ helm template . -f example.yaml | grep "image:"
          image: myrepository.com/kube-proxy:v1.0.0
          image: myrepository.com/kube-proxy:v1.0.0
```

Test without the tag value:
```
❯ cat example.yaml
image:
  repository: myrepository.com/kube-proxy
  #tag: v1.0.0

apiServer:
  endpoint: https://myapiserver.com

❯ helm template . -f example.yaml | grep "image:"
Error: execution error at (kube-proxy/templates/daemonset.yaml:56:20): At least one of image.tag or image.digest must be provided

Use --debug flag to render out invalid YAML
```