### PR TITLE
fix(nexus3):add apiVersion and kind to volumeClaimTemplates

### DIFF
--- a/charts/nexus3/templates/statefulset.yaml
+++ b/charts/nexus3/templates/statefulset.yaml
@@ -403,7 +403,9 @@ spec:
       {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim 
+      metadata:
         name: data
         labels:
           {{- include "nexus3.selectorLabels" . | nindent 10 }}


### PR DESCRIPTION
The apiVersion and kind fields in volumeClaimTemplates are required by the Kubernetes API specification.

It is always out of sync after deployment by using Argo CD.

<img width="985" height="275" alt="image" src="https://github.com/user-attachments/assets/01ae0afc-b154-4ab6-a7ae-51aa16005f97" />

