### PR TITLE
fix(nexus3): implementation of config.job.annotations to correctly annotate the job and not the job pod

### DIFF
--- a/charts/nexus3/CHANGELOG.md
+++ b/charts/nexus3/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fix implementation of `config.job.annotations` to correctly annotate the job and not the job pod. ([#1234](https://github.com/stevehipwell/helm-charts/pull/1234)) _@falltrades_
+
 ## [v5.13.0] - 2025-08-14
 
 ### Added

--- a/charts/nexus3/templates/job-config.yaml
+++ b/charts/nexus3/templates/job-config.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nexus3.labels" . | nindent 4 }}
+{{- with .Values.config.job.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   template:
     metadata:
@@ -15,9 +19,6 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
         checksum/scripts: {{ include (print $.Template.BasePath "/configmap-scripts.yaml") . | sha256sum }}
-      {{- with .Values.config.job.annotations }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
     spec:
       restartPolicy: Never
       containers:


### PR DESCRIPTION
Related to: https://github.com/stevehipwell/helm-charts/issues/1222

Sorry for this PR, after deploying, I figured I needed custom annotations for the job parent.

test cases:
```shell
helm template . --set config.enabled=true --set rootPassword.secret=test --set config.job.ttlSecondsAfterFinished="" --set-string config.job.annotations."argocd\.argoproj\.io/hook"=PostSync --set-string config.job.annotations."argocd\.argoproj\.io/hook-delete-policy"=HookSucceeded  --show-only templates/job-config.yaml
```