### PR TITLE
feat(thanos/compact): add native support for retention, concurrency, and deduplication flags

### DIFF
--- a/charts/thanos/CHANGELOG.md
+++ b/charts/thanos/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Added
+- Added native support for Compact flags: `retentionResolution` (raw, 5m, 1h), `concurrency`, `downsampleConcurrency`, and `deleteDelay`. ([#1343](https://github.com/stevehipwell/helm-charts/pull/1343)) _@Poil_
+- Added support for `replicaLabels` as an array in the Compact component for easier deduplication management. ([#1343](https://github.com/stevehipwell/helm-charts/pull/1343)) _@Poil_
+
 ## [v1.23.0] - 2026-03-02
 
 ### Added

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -58,8 +58,12 @@ helm upgrade --install thanos stevehipwell/thanos --version 1.23.0
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | compact.affinity | object | `{}` | Affinity settings for scheduling the _Compact_ pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |
 | compact.automountServiceAccountToken | bool | `nil` | If the service account token should be mounted to the _Compact_ pod, this overrides `compact.serviceAccount.automountToken`. |
+| compact.concurrency | int | `1` | Number of goroutines to use when compacting blocks. |
 | compact.deduplication.enabled | bool | `true` | If `true`, enable deduplication via the _Compact_ component. |
 | compact.deduplication.func | string | `nil` | If specified override the default deduplication function. |
+| compact.deduplication.replicaLabels | list | `[]` | Labels to treat as a replica label for deduplication. |
+| compact.deleteDelay | string | `"48h"` | Time before a block marked for deletion is deleted from bucket. |
+| compact.downsampleConcurrency | int | `1` | Number of goroutines to use when downsampling blocks. |
 | compact.enabled | bool | `false` | If `true`, create the _Thanos Compact_ component. |
 | compact.extraArgs | list | `[]` | Additional args for the _Compact_ pod default container. |
 | compact.extraEnv | list | `[]` | Additional environment variables for the _Compact_ pod default container. |
@@ -82,6 +86,10 @@ helm upgrade --install thanos stevehipwell/thanos --version 1.23.0
 | compact.readinessProbe | object | See _values.yaml_ | Readiness probe configuration for the _Compact_ pod default container. |
 | compact.replicaDeduplication | bool | `false` | **DEPRECATED** - If `true`, use the `penalty` deduplication function optimized for HA Prometheus replicas. |
 | compact.resources | object | `{}` | Resources for the _Compact_ pod default container. |
+| compact.retentionResolution | object | `{"1h":"0d","5m":"90d","raw":"30d"}` | How long to retain samples of various resolutions in bucket. 0d or empty means forever. |
+| compact.retentionResolution.1h | string | `"0d"` | How long to retain samples of 1h resolution in bucket. |
+| compact.retentionResolution.5m | string | `"90d"` | How long to retain samples of 5m resolution in bucket. |
+| compact.retentionResolution.raw | string | `"30d"` | How long to retain raw samples in bucket. |
 | compact.securityContext | object | See _values.yaml_ | Security context for the _Compact_ pod default container. |
 | compact.service.annotations | object | `{}` | Annotations to add to the _Compact_ service. |
 | compact.service.httpPort | int | `10902` | HTTP port for the _Compact_ service. |

--- a/charts/thanos/templates/compact/statefulset.yaml
+++ b/charts/thanos/templates/compact/statefulset.yaml
@@ -81,20 +81,41 @@ spec:
             - --objstore.config-file=/etc/thanos/objstore.yaml
           {{- if .Values.autoGomemlimit.enabled }}
             - --enable-auto-gomemlimit
-          {{- with .Values.autoGomemlimit.ratio }}
+            {{- with .Values.autoGomemlimit.ratio }}
             - {{ printf "--auto-gomemlimit.ratio=%s" . }}
-          {{- end }}
+            {{- end }}
           {{- end }}
           {{- if .Values.compact.deduplication.enabled }}
             - --compact.enable-vertical-compaction
-          {{- range (concat .Values.additionalReplicaLabels (ternary (list "rule_replica") (list) .Values.rule.enabled ) (ternary (list "receive_replica") (list) .Values.receive.enabled )) | uniq }}
+            {{- range (concat .Values.additionalReplicaLabels (ternary (list "rule_replica") (list) .Values.rule.enabled ) (ternary (list "receive_replica") (list) .Values.receive.enabled )) | uniq }}
             - {{ printf "--deduplication.replica-label=%s" . }}
-          {{- end }}
-          {{- if .Values.compact.deduplication.func }}
+            {{- end }}
+            {{- if .Values.compact.deduplication.func }}
             - {{ printf "--deduplication.func=%s" .Values.compact.deduplication.func }}
-          {{- else if .Values.compact.replicaDeduplication }}
+            {{- else if .Values.compact.replicaDeduplication }}
             - --deduplication.func=penalty
+            {{- end }}
           {{- end }}
+          {{- if .Values.compact.retentionResolution }}
+            - {{ printf "--retention.resolution-raw=%s" (index .Values.compact.retentionResolution "raw" | default "0s") }}
+            - {{ printf "--retention.resolution-5m=%s" (index .Values.compact.retentionResolution "5m" | default "0s") }}
+            - {{ printf "--retention.resolution-1h=%s" (index .Values.compact.retentionResolution "1h" | default "0s") }}
+          {{- end }}
+          {{- if .Values.compact.concurrency }}
+            - {{ printf "--compact.concurrency=%d" (int .Values.compact.concurrency) }}
+          {{- end }}
+          {{- if .Values.compact.downsampleConcurrency }}
+            - {{ printf "--downsample.concurrency=%d" (int .Values.compact.downsampleConcurrency) }}
+          {{- end }}
+          {{- if .Values.compact.deleteDelay }}
+            - {{ printf "--delete-delay=%s" .Values.compact.deleteDelay }}
+          {{- end }}
+
+          {{- /* Loop over custom replica labels */ -}}
+          {{- if .Values.compact.deduplication.enabled }}
+            {{- range .Values.compact.deduplication.replicaLabels }}
+            - {{ printf "--deduplication.replica-label=%s" . }}
+            {{- end }}
           {{- end }}
           {{- with .Values.compact.extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -85,9 +85,29 @@ compact:
     enabled: true
     # -- (string) If specified override the default deduplication function.
     func:
+    # -- Labels to treat as a replica label for deduplication.
+    replicaLabels: []
 
   # -- **DEPRECATED** - If `true`, use the `penalty` deduplication function optimized for HA Prometheus replicas.
   replicaDeduplication: false
+
+  # -- How long to retain samples of various resolutions in bucket. 0d or empty means forever.
+  retentionResolution:
+    # -- How long to retain raw samples in bucket.
+    raw: 30d
+    # -- How long to retain samples of 5m resolution in bucket.
+    5m: 90d
+    # -- How long to retain samples of 1h resolution in bucket.
+    1h: 0d
+
+  # -- Number of goroutines to use when compacting blocks.
+  concurrency: 1
+
+  # -- Number of goroutines to use when downsampling blocks.
+  downsampleConcurrency: 1
+
+  # -- Time before a block marked for deletion is deleted from bucket.
+  deleteDelay: 48h
 
   serviceAccount:
     # -- If `true`, create a new `ServiceAccount` for the _Compact_ component.


### PR DESCRIPTION
Managing multiple Thanos clusters currently involves significant configuration overhead, as retention and concurrency parameters must be manually defined in extraArgs. This PR introduces native support for these flags to streamline multi-cluster deployments and improve maintainability