### PR TITLE
feat(thanos): add trafficDistribution to rule and receive-router svc

### DIFF
--- a/charts/thanos/CHANGELOG.md
+++ b/charts/thanos/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 - Fixed float64 formatting in compact auto-gomemlimit ratio ([#1345](https://github.com/stevehipwell/helm-charts/pull/1345)) @Poil
 
+### Added
+
+- Added `receive.router.service.trafficDistribution` and `rule.service.trafficDistribution` values to allow configuring the `trafficDistribution` [#1366](https://github.com/stevehipwell/helm-charts/pull/1366) _@draegerben_
+
 ## [v1.23.0] - 2026-03-02
 
 ### Added

--- a/charts/thanos/CHANGELOG.md
+++ b/charts/thanos/CHANGELOG.md
@@ -28,6 +28,17 @@
 ### Added
 
 - Added `receive.router.service.trafficDistribution` and `rule.service.trafficDistribution` values to allow configuring the `trafficDistribution` [#1366](https://github.com/stevehipwell/helm-charts/pull/1366) _@draegerben_
+### Added
+
+- Add support for specifying labels on persistence volume claims. ([#1372](https://github.com/stevehipwell/helm-charts/pull/1372)) @stevehipwell
+- Add support for GRPC ingress to the _Thanos Query_ component. ([#1372](https://github.com/stevehipwell/helm-charts/pull/1372)) @stevehipwell
+- Add optional `HTTPRoute` resource support to the _Query_, _Query Frontend_, _Receive Router_, & _Rule_ components via the new `httpRoute` values. ([#1374](https://github.com/stevehipwell/helm-charts/pull/1374)) @stevehipwell
+- Add optional `GRPCRoute` resource support to the _Query_ component via the new `query.grpcRoute` values. ([#1374](https://github.com/stevehipwell/helm-charts/pull/1374)) @stevehipwell
+- Added `receive.router.service.trafficDistribution` and `rule.service.trafficDistribution` values to allow configuring the `trafficDistribution` [#1366](https://github.com/stevehipwell/helm-charts/pull/1366) _@draegerben_
+
+### Fixed
+
+- Fixed float64 formatting in compact auto-gomemlimit ratio ([#1345](https://github.com/stevehipwell/helm-charts/pull/1345)) @Poil
 
 ## [v1.23.0] - 2026-03-02
 

--- a/charts/thanos/CHANGELOG.md
+++ b/charts/thanos/CHANGELOG.md
@@ -20,20 +20,6 @@
 - Add support for GRPC ingress to the _Thanos Query_ component. ([#1372](https://github.com/stevehipwell/helm-charts/pull/1372)) @stevehipwell
 - Add optional `HTTPRoute` resource support to the _Query_, _Query Frontend_, _Receive Router_, & _Rule_ components via the new `httpRoute` values. ([#1374](https://github.com/stevehipwell/helm-charts/pull/1374)) @stevehipwell
 - Add optional `GRPCRoute` resource support to the _Query_ component via the new `query.grpcRoute` values. ([#1374](https://github.com/stevehipwell/helm-charts/pull/1374)) @stevehipwell
-
-### Fixed
-
-- Fixed float64 formatting in compact auto-gomemlimit ratio ([#1345](https://github.com/stevehipwell/helm-charts/pull/1345)) @Poil
-
-### Added
-
-- Added `receive.router.service.trafficDistribution` and `rule.service.trafficDistribution` values to allow configuring the `trafficDistribution` [#1366](https://github.com/stevehipwell/helm-charts/pull/1366) _@draegerben_
-### Added
-
-- Add support for specifying labels on persistence volume claims. ([#1372](https://github.com/stevehipwell/helm-charts/pull/1372)) @stevehipwell
-- Add support for GRPC ingress to the _Thanos Query_ component. ([#1372](https://github.com/stevehipwell/helm-charts/pull/1372)) @stevehipwell
-- Add optional `HTTPRoute` resource support to the _Query_, _Query Frontend_, _Receive Router_, & _Rule_ components via the new `httpRoute` values. ([#1374](https://github.com/stevehipwell/helm-charts/pull/1374)) @stevehipwell
-- Add optional `GRPCRoute` resource support to the _Query_ component via the new `query.grpcRoute` values. ([#1374](https://github.com/stevehipwell/helm-charts/pull/1374)) @stevehipwell
 - Added `receive.router.service.trafficDistribution` and `rule.service.trafficDistribution` values to allow configuring the `trafficDistribution` [#1366](https://github.com/stevehipwell/helm-charts/pull/1366) _@draegerben_
 
 ### Fixed

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -316,6 +316,7 @@ helm upgrade --install thanos stevehipwell/thanos --version 1.23.0
 | receive.router.service.grpcPort | int | `10901` | GRPC port for the _Receive Router_ service. |
 | receive.router.service.httpPort | int | `10902` | HTTP port for the _Receive Router_ service. |
 | receive.router.service.httpRemoteWritePort | int | `19291` | HTTP remote write port for the _Receive Router_ service. |
+| receive.router.service.trafficDistribution | string | `nil` | Traffic distribution for the _Receive Router_ service. |
 | receive.router.service.type | string | `"ClusterIP"` | Service type for the _Receive Router_ service. |
 | receive.router.serviceAccount.annotations | object | `{}` | Annotations to add to the _Receive Router_ service account. |
 | receive.router.serviceAccount.automountToken | bool | `false` | Automount API credentials for the _Receive Router_ service account. |
@@ -391,6 +392,7 @@ helm upgrade --install thanos stevehipwell/thanos --version 1.23.0
 | rule.service.annotations | object | `{}` | Annotations to add to the _Rule_ service. |
 | rule.service.grpcPort | int | `10901` | GRPC port for the _Rule_ service. |
 | rule.service.httpPort | int | `10902` | HTTP port for the _Rule_ service. |
+| rule.service.trafficDistribution | string | `nil` | Traffic distribution for the _Rule_ service. |
 | rule.service.type | string | `"ClusterIP"` | Service type for the _Rule_ service. |
 | rule.serviceAccount.annotations | object | `{}` | Annotations to add to the _Rule_ service account. |
 | rule.serviceAccount.automountToken | bool | `false` | Automount API credentials for the _Rule_ service account. |

--- a/charts/thanos/templates/receive-router/service.yaml
+++ b/charts/thanos/templates/receive-router/service.yaml
@@ -12,6 +12,11 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.receive.router.service.type }}
+{{- if (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+{{- with .Values.receive.router.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+{{- end }}
+{{- end }}
   ports:
     - name: grpc
       port: {{ .Values.receive.router.service.grpcPort }}

--- a/charts/thanos/templates/rule/service.yaml
+++ b/charts/thanos/templates/rule/service.yaml
@@ -13,6 +13,11 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.rule.service.type }}
+{{- if (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+{{- with .Values.rule.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+{{- end }}
+{{- end }}
   ports:
     - name: grpc
       port: {{ .Values.rule.service.grpcPort }}

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -831,6 +831,8 @@ receive:
       httpPort: 10902
       # -- HTTP remote write port for the _Receive Router_ service.
       httpRemoteWritePort: 19291
+      # -- (string) Traffic distribution for the _Receive Router_ service.
+      trafficDistribution:
       # -- Service type for the _Receive Router_ service.
       type: ClusterIP
 
@@ -1060,6 +1062,8 @@ rule:
     grpcPort: 10901
     # -- HTTP port for the _Rule_ service.
     httpPort: 10902
+    # -- (string) Traffic distribution for the _Rule_ service.
+    trafficDistribution:
     # -- Service type for the _Rule_ service.
     type: ClusterIP
 

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -761,6 +761,8 @@ receive:
       httpPort: 10902
       # -- HTTP remote write port for the _Receive Router_ service.
       httpRemoteWritePort: 19291
+      # -- (string) Traffic distribution for the _Receive Router_ service.
+      trafficDistribution:
       # -- Service type for the _Receive Router_ service.
       type: ClusterIP
 
@@ -970,6 +972,8 @@ rule:
     grpcPort: 10901
     # -- HTTP port for the _Rule_ service.
     httpPort: 10902
+    # -- (string) Traffic distribution for the _Rule_ service.
+    trafficDistribution:
     # -- Service type for the _Rule_ service.
     type: ClusterIP
 


### PR DESCRIPTION
This PR adds `trafficDistribution` to the Thanos Rule and Thanos Receive Router services.

closes #1375 